### PR TITLE
feat: Auto-provision SlotManager on calendar create/deactivate

### DIFF
--- a/src/main/java/com/microboxlabs/miot/calendar/entity/SlotManager.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/SlotManager.java
@@ -7,7 +7,9 @@ import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * SlotManager Entity
@@ -86,5 +88,15 @@ public class SlotManager extends PanacheEntityBase {
 
     public static List<SlotManager> findAllActive() {
         return list("active", true);
+    }
+
+    public static Set<UUID> findCalendarIdsWithManager(List<UUID> calendarIds) {
+        if (calendarIds == null || calendarIds.isEmpty()) {
+            return Set.of();
+        }
+        return find("calendar.id in ?1", calendarIds)
+            .<SlotManager>stream()
+            .map(sm -> sm.calendar.id)
+            .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/CalendarRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/CalendarRequest.java
@@ -25,7 +25,10 @@ public record CalendarRequest(
     Boolean active,
 
     @Schema(description = "List of group codes to assign. null = no change; [] = remove all; [\"code1\"] = replace all")
-    List<String> groups
+    List<String> groups,
+
+    @Schema(description = "Whether to auto-provision a default SlotManager on creation. Defaults to true when null.", defaultValue = "true")
+    Boolean autoSlotManager
 ) {
     /**
      * Validate the calendar request

--- a/src/main/java/com/microboxlabs/miot/calendar/model/CalendarResponse.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/CalendarResponse.java
@@ -37,12 +37,15 @@ public record CalendarResponse(
     ZonedDateTime updatedAt,
 
     @Schema(description = "Groups this calendar belongs to")
-    List<CalendarGroupResponse> groups
+    List<CalendarGroupResponse> groups,
+
+    @Schema(description = "Whether this calendar has a SlotManager provisioned")
+    Boolean hasSlotManager
 ) {
     /**
      * Create from entity
      */
-    public static CalendarResponse from(Calendar calendar) {
+    public static CalendarResponse from(Calendar calendar, boolean hasSlotManager) {
         List<CalendarGroupResponse> groupResponses = calendar.groups != null
             ? calendar.groups.stream().map(CalendarGroupResponse::from).toList()
             : List.of();
@@ -55,7 +58,8 @@ public record CalendarResponse(
             calendar.active,
             calendar.createdAt,
             calendar.updatedAt,
-            groupResponses
+            groupResponses,
+            hasSlotManager
         );
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/resource/CalendarResource.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/resource/CalendarResource.java
@@ -19,6 +19,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -52,8 +53,11 @@ public class CalendarResource {
                 : calendarService.getAllCalendars();
         }
 
+        Set<UUID> idsWithManager = SlotManager.findCalendarIdsWithManager(
+            calendars.stream().map(c -> c.id).toList());
+
         List<CalendarResponse> response = calendars.stream()
-            .map(c -> CalendarResponse.from(c, hasSlotManager(c.id)))
+            .map(c -> CalendarResponse.from(c, idsWithManager.contains(c.id)))
             .toList();
 
         return Response.ok(response).build();

--- a/src/main/java/com/microboxlabs/miot/calendar/resource/CalendarResource.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/resource/CalendarResource.java
@@ -1,6 +1,7 @@
 package com.microboxlabs.miot.calendar.resource;
 
 import com.microboxlabs.miot.calendar.entity.Calendar;
+import com.microboxlabs.miot.calendar.entity.SlotManager;
 import com.microboxlabs.miot.calendar.entity.TimeWindow;
 import com.microboxlabs.miot.calendar.model.*;
 import com.microboxlabs.miot.calendar.service.CalendarService;
@@ -52,7 +53,7 @@ public class CalendarResource {
         }
 
         List<CalendarResponse> response = calendars.stream()
-            .map(CalendarResponse::from)
+            .map(c -> CalendarResponse.from(c, hasSlotManager(c.id)))
             .toList();
 
         return Response.ok(response).build();
@@ -69,7 +70,7 @@ public class CalendarResource {
     public Response getCalendar(
             @Parameter(description = "Unique identifier of the calendar", required = true) @PathParam("id") UUID id) {
         return calendarService.getCalendarById(id)
-            .map(calendar -> Response.ok(CalendarResponse.from(calendar)).build())
+            .map(calendar -> Response.ok(CalendarResponse.from(calendar, hasSlotManager(calendar.id))).build())
             .orElse(Response.status(Response.Status.NOT_FOUND)
                 .entity(ErrorResponse.notFound("Calendar not found: " + id))
                 .build());
@@ -86,7 +87,7 @@ public class CalendarResource {
         try {
             Calendar calendar = calendarService.createCalendar(request);
             return Response.status(Response.Status.CREATED)
-                .entity(CalendarResponse.from(calendar))
+                .entity(CalendarResponse.from(calendar, hasSlotManager(calendar.id)))
                 .build();
         } catch (IllegalArgumentException e) {
             LOG.warnf("Invalid calendar request: %s", e.getMessage());
@@ -111,7 +112,7 @@ public class CalendarResource {
             CalendarRequest request) {
         try {
             Calendar calendar = calendarService.updateCalendar(id, request);
-            return Response.ok(CalendarResponse.from(calendar)).build();
+            return Response.ok(CalendarResponse.from(calendar, hasSlotManager(calendar.id))).build();
         } catch (IllegalArgumentException e) {
             if (e.getMessage().contains("not found")) {
                 return Response.status(Response.Status.NOT_FOUND)
@@ -141,6 +142,10 @@ public class CalendarResource {
                 .entity(ErrorResponse.notFound(e.getMessage()))
                 .build();
         }
+    }
+
+    private boolean hasSlotManager(UUID calendarId) {
+        return SlotManager.findByCalendarId(calendarId) != null;
     }
 
     // Time Window endpoints

--- a/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
@@ -25,8 +25,12 @@ public class CalendarService {
     @Inject
     CalendarGroupService calendarGroupService;
 
+    private final SlotManagerService slotManagerService;
+
     @Inject
-    SlotManagerService slotManagerService;
+    public CalendarService(SlotManagerService slotManagerService) {
+        this.slotManagerService = slotManagerService;
+    }
 
     /**
      * Get all calendars

--- a/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
@@ -25,6 +25,9 @@ public class CalendarService {
     @Inject
     CalendarGroupService calendarGroupService;
 
+    @Inject
+    SlotManagerService slotManagerService;
+
     /**
      * Get all calendars
      */
@@ -89,6 +92,12 @@ public class CalendarService {
             resolveAndAssignGroups(calendar, request.groups());
         }
 
+        // Auto-provision SlotManager (defaults to true when null)
+        boolean autoSlotManager = request.autoSlotManager() == null || request.autoSlotManager();
+        if (autoSlotManager) {
+            slotManagerService.createDefaultManager(calendar);
+        }
+
         LOG.infof("Created calendar: %s (%s)", calendar.name, calendar.code);
 
         return calendar;
@@ -147,6 +156,7 @@ public class CalendarService {
             throw new IllegalArgumentException("Calendar not found: " + id);
         }
         calendar.active = false;
+        slotManagerService.deactivateManagerByCalendarId(id);
         LOG.infof("Deactivated calendar: %s (%s)", calendar.name, calendar.code);
     }
 

--- a/src/main/java/com/microboxlabs/miot/calendar/service/SlotManagerService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/SlotManagerService.java
@@ -129,6 +129,44 @@ public class SlotManagerService {
         LOG.infof("Deactivated slot manager %s for calendar %s", id, manager.calendar.code);
     }
 
+    // ── Auto-provision helpers (package-private, called by CalendarService) ──
+
+    /**
+     * Creates a default SlotManager for the given calendar.
+     * Guards against duplicates via findByCalendarId.
+     */
+    @Transactional
+    SlotManager createDefaultManager(Calendar calendar) {
+        if (SlotManager.findByCalendarId(calendar.id) != null) {
+            LOG.warnf("Slot manager already exists for calendar %s, skipping auto-provision", calendar.code);
+            return SlotManager.findByCalendarId(calendar.id);
+        }
+
+        SlotManager manager = new SlotManager();
+        manager.calendar = calendar;
+        manager.active = true;
+        manager.daysInAdvance = 30;
+        manager.batchDays = 7;
+        manager.persist();
+
+        LOG.infof("Auto-provisioned slot manager for calendar %s", calendar.code);
+        return manager;
+    }
+
+    /**
+     * Deactivates the SlotManager for the given calendar, if one exists.
+     * Returns silently if none exists (handles calendars created with autoSlotManager=false).
+     */
+    @Transactional
+    void deactivateManagerByCalendarId(UUID calendarId) {
+        SlotManager manager = SlotManager.findByCalendarId(calendarId);
+        if (manager == null) {
+            return;
+        }
+        manager.active = false;
+        LOG.infof("Deactivated slot manager for calendar %s", manager.calendar.code);
+    }
+
     // ── Run lifecycle ─────────────────────────────────────────────────────
 
     /**

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/CalendarResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/CalendarResourceTest.java
@@ -53,6 +53,7 @@ class CalendarResourceTest {
             .body("code", equalTo("test-calendar"))
             .body("name", equalTo("Test Calendar"))
             .body("active", equalTo(true))
+            .body("hasSlotManager", equalTo(true))
             .extract()
             .path("id");
     }
@@ -76,7 +77,8 @@ class CalendarResourceTest {
             .get("/api/v1/miot-calendar/calendars/" + calendarId)
             .then()
             .statusCode(200)
-            .body("code", equalTo("test-calendar"));
+            .body("code", equalTo("test-calendar"))
+            .body("hasSlotManager", equalTo(true));
     }
 
     @Test
@@ -93,7 +95,8 @@ class CalendarResourceTest {
             .put("/api/v1/miot-calendar/calendars/" + calendarId)
             .then()
             .statusCode(200)
-            .body("name", equalTo("Updated Test Calendar"));
+            .body("name", equalTo("Updated Test Calendar"))
+            .body("hasSlotManager", equalTo(true));
     }
 
     @Test
@@ -147,7 +150,28 @@ class CalendarResourceTest {
             .get("/api/v1/miot-calendar/calendars/" + calendarId)
             .then()
             .statusCode(200)
-            .body("active", equalTo(false));
+            .body("active", equalTo(false))
+            .body("hasSlotManager", equalTo(true));
+    }
+
+    @Test
+    void testCreateCalendarWithoutAutoSlotManager() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "code": "no-auto-mgr",
+                    "name": "No Auto Manager",
+                    "timezone": "UTC",
+                    "autoSlotManager": false
+                }
+                """)
+            .when()
+            .post("/api/v1/miot-calendar/calendars")
+            .then()
+            .statusCode(201)
+            .body("code", equalTo("no-auto-mgr"))
+            .body("hasSlotManager", equalTo(false));
     }
 
     @Test

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/SlotManagerResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/SlotManagerResourceTest.java
@@ -42,7 +42,8 @@ class SlotManagerResourceTest {
                 {
                     "code": "mgr-test-calendar",
                     "name": "Manager Test Calendar",
-                    "timezone": "America/Santiago"
+                    "timezone": "America/Santiago",
+                    "autoSlotManager": false
                 }
                 """)
             .when()


### PR DESCRIPTION
## Summary

- Automatically creates a default SlotManager (active=true, daysInAdvance=30, batchDays=7) when a calendar is created, and deactivates it when the calendar is deactivated — both within a single transaction
- Adds autoSlotManager opt-out flag to CalendarRequest (defaults to true) so callers can skip auto-provisioning
- Adds hasSlotManager field to CalendarResponse for visibility into provisioning state

## Test plan

- [x] All 59 existing tests pass (including updated assertions)
- [x] testCreateCalendar asserts hasSlotManager: true on default creation
- [x] testCreateCalendarWithoutAutoSlotManager asserts hasSlotManager: false with opt-out
- [x] testDeactivateCalendar verifies manager still exists (just inactive)
- [x] SlotManagerResourceTest.setupCalendar uses autoSlotManager: false to avoid duplicate conflict in testCreateManager

Closes #5

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an autoSlotManager parameter on calendar creation (defaults true).
  * Calendar responses now include a hasSlotManager flag indicating slot-manager status.
  * Calendar create, update, list and deactivate flows now surface the hasSlotManager state.

* **Tests**
  * Updated and added tests to validate hasSlotManager behavior for creation, retrieval, update and deactivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->