### PR TITLE
fix: slot generation always produced 0 slots (#9)

### DIFF
--- a/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
@@ -43,7 +43,7 @@ public class TimeWindow extends PanacheEntityBase {
     public Integer capacityPerSlot = 1;
 
     @Column(name = "days_of_week", length = 50)
-    public String daysOfWeek = "MON,TUE,WED,THU,FRI";
+    public String daysOfWeek = "1,2,3,4,5";
 
     @Column(name = "valid_from", nullable = false)
     public LocalDate validFrom;
@@ -97,6 +97,11 @@ public class TimeWindow extends PanacheEntityBase {
         if (daysOfWeek == null || daysOfWeek.isEmpty()) {
             return false;
         }
-        return daysOfWeek.contains(dayOfWeek);
+        for (String token : daysOfWeek.split(",")) {
+            if (token.trim().equals(dayOfWeek)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/service/SlotGeneratorService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/SlotGeneratorService.java
@@ -59,7 +59,7 @@ public class SlotGeneratorService {
                 int hour = timeWindow.startHour;
                 int minutes = 0;
 
-                while (hour < timeWindow.endHour || (hour == timeWindow.endHour && minutes == 0)) {
+                while (hour < timeWindow.endHour) {
                     // Check if slot already exists
                     Slot existing = Slot.findByCalendarAndDateTime(calendarId, date, hour, minutes);
                     
@@ -97,17 +97,10 @@ public class SlotGeneratorService {
     }
 
     /**
-     * Convert DayOfWeek to string code
+     * Convert DayOfWeek to its ISO numeric string (1=Monday … 7=Sunday),
+     * matching the format stored by the API ("daysOfWeek": "1,2,3,4,5").
      */
     private String getDayOfWeekCode(DayOfWeek dayOfWeek) {
-        return switch (dayOfWeek) {
-            case MONDAY -> "MON";
-            case TUESDAY -> "TUE";
-            case WEDNESDAY -> "WED";
-            case THURSDAY -> "THU";
-            case FRIDAY -> "FRI";
-            case SATURDAY -> "SAT";
-            case SUNDAY -> "SUN";
-        };
+        return String.valueOf(dayOfWeek.getValue());
     }
 }

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
@@ -28,6 +28,12 @@ class BookingResourceTest {
     @TestHTTPResource
     URL url;
 
+    @TestHTTPEndpoint(BookingResource.class)
+    @TestHTTPResource
+    URL bookingsUrl;
+
+    private static final String RESOURCE_ID = "%s";
+
     private String calendarId;
     private String bookingId;
     private LocalDate slotDate;
@@ -73,7 +79,7 @@ class BookingResourceTest {
                     "endHour": 17,
                     "slotDurationMinutes": 30,
                     "capacityPerSlot": 2,
-                    "daysOfWeek": "MON,TUE,WED,THU,FRI,SAT,SUN",
+                    "daysOfWeek": "1,2,3,4,5,6,7",
                     "validFrom": "%s"
                 }
                 """, LocalDate.now().toString()))
@@ -108,7 +114,7 @@ class BookingResourceTest {
                 {
                     "calendarId": "%s",
                     "resource": {
-                        "id": "SRV-001",
+                        "id": "%s",
                         "type": "SERVICE",
                         "label": "Acme Corp - Santiago to Valparaiso",
                         "data": {
@@ -124,12 +130,12 @@ class BookingResourceTest {
                         "minutes": %d
                     }
                 }
-                """, calendarId, slotDate, slotHour, slotMinutes))
+                """, calendarId, RESOURCE_ID, slotDate, slotHour, slotMinutes))
             .when()
-            .post("/api/v1/miot-calendar/bookings")
+            .post(bookingsUrl.toString())
             .then()
             .statusCode(201)
-            .body("resource.id", equalTo("SRV-001"))
+            .body("resource.id", equalTo(RESOURCE_ID))
             .body("resource.type", equalTo("SERVICE"))
             .body("createdBy", equalTo("test-user"))
             .extract()
@@ -144,11 +150,11 @@ class BookingResourceTest {
             .queryParam("startDate", slotDate.toString())
             .queryParam("endDate", slotDate.plusDays(7).toString())
             .when()
-            .get("/api/v1/miot-calendar/bookings")
+            .get(bookingsUrl.toString())
             .then()
             .statusCode(200)
             .body("data.size()", greaterThan(0))
-            .body("data[0].resource.id", equalTo("SRV-001"));
+            .body("data[0].resource.id", equalTo(RESOURCE_ID));
     }
 
     @Test
@@ -156,11 +162,11 @@ class BookingResourceTest {
     void testGetBooking() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/bookings/" + bookingId)
+            .get(bookingsUrl + "/" + bookingId)
             .then()
             .statusCode(200)
             .body("id", equalTo(bookingId))
-            .body("resource.id", equalTo("SRV-001"));
+            .body("resource.id", equalTo(RESOURCE_ID));
     }
 
     @Test
@@ -168,7 +174,7 @@ class BookingResourceTest {
     void testGetBookingsByResource() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/bookings/resource/SRV-001")
+            .get(bookingsUrl + "/resource/" + RESOURCE_ID)
             .then()
             .statusCode(200)
             .body("data.size()", greaterThan(0));
@@ -184,7 +190,7 @@ class BookingResourceTest {
                 {
                     "calendarId": "%s",
                     "resource": {
-                        "id": "SRV-001",
+                        "id": "%s",
                         "type": "SERVICE",
                         "label": "Duplicate booking"
                     },
@@ -194,9 +200,9 @@ class BookingResourceTest {
                         "minutes": %d
                     }
                 }
-                """, calendarId, slotDate, slotHour, slotMinutes))
+                """, calendarId, RESOURCE_ID, slotDate, slotHour, slotMinutes))
             .when()
-            .post("/api/v1/miot-calendar/bookings")
+            .post(bookingsUrl.toString())
             .then()
             .statusCode(409); // Conflict
     }
@@ -223,7 +229,7 @@ class BookingResourceTest {
                 }
                 """, calendarId, slotDate, slotHour, slotMinutes))
             .when()
-            .post("/api/v1/miot-calendar/bookings")
+            .post(bookingsUrl.toString())
             .then()
             .statusCode(201);
     }
@@ -250,7 +256,7 @@ class BookingResourceTest {
                 }
                 """, calendarId, slotDate, slotHour, slotMinutes))
             .when()
-            .post("/api/v1/miot-calendar/bookings")
+            .post(bookingsUrl.toString())
             .then()
             .statusCode(409); // Conflict - slot full
     }
@@ -260,14 +266,14 @@ class BookingResourceTest {
     void testCancelBooking() {
         given()
             .when()
-            .delete("/api/v1/miot-calendar/bookings/" + bookingId)
+            .delete(bookingsUrl + "/" + bookingId)
             .then()
             .statusCode(204);
 
         // Verify booking is gone
         given()
             .when()
-            .get("/api/v1/miot-calendar/bookings/" + bookingId)
+            .get(bookingsUrl + "/" + bookingId)
             .then()
             .statusCode(404);
     }
@@ -284,7 +290,7 @@ class BookingResourceTest {
                 }
                 """)
             .when()
-            .post("/api/v1/miot-calendar/bookings")
+            .post(bookingsUrl.toString())
             .then()
             .statusCode(400);
     }
@@ -293,7 +299,7 @@ class BookingResourceTest {
     void testBookingNotFound() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/bookings/00000000-0000-0000-0000-000000000000")
+            .get(bookingsUrl + "/00000000-0000-0000-0000-000000000000")
             .then()
             .statusCode(404);
     }

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/SlotGenerationTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/SlotGenerationTest.java
@@ -1,0 +1,196 @@
+package com.microboxlabs.miot.calendar.resource;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.*;
+
+import java.net.URL;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration tests for slot generation correctness.
+ *
+ * Covers two bugs fixed together:
+ *
+ *   Bug 1 – day-of-week filter was broken:
+ *     The API schema described numeric codes ("1,2,3,4,5") while the generator
+ *     produced 3-letter codes ("MON"…"SUN"). includesDay() used String.contains(),
+ *     so "1,2,3,4,5".contains("MON") == false — every date was silently skipped
+ *     and 0 slots were ever created.
+ *
+ *   Bug 2 – endHour was treated as inclusive:
+ *     The while-loop condition `hour < endHour || (hour == endHour && minutes == 0)`
+ *     emitted one extra slot AT endHour. For an 08:00–12:00 window with 60-min
+ *     slots the generator created 5 slots (8,9,10,11,12) instead of the documented
+ *     4 (8,9,10,11).
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SlotGenerationTest {
+
+    private static final String SLOTS_GENERATE_BODY = """
+            {
+                "calendarId": "%s",
+                "startDate": "%s",
+                "endDate":   "%s"
+            }
+            """;
+    private static final String SLOTS_CREATED  = "slotsCreated";
+    private static final String SLOTS_SKIPPED  = "slotsSkipped";
+
+    @TestHTTPResource
+    URL url;
+
+    @TestHTTPEndpoint(SlotResource.class)
+    @TestHTTPResource("generate")
+    URL slotsGenerateUrl;
+
+    private String calendarId;
+
+    // Use a fixed Sunday and the following Monday so that both dates are
+    // always >= today (validFrom) regardless of which day the suite runs.
+    private static final LocalDate A_SUNDAY =
+            LocalDate.now().with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+    private static final LocalDate A_MONDAY =
+            LocalDate.now().with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY));
+
+    @BeforeEach
+    void setupRestAssured() {
+        RestAssured.baseURI = url.toString();
+        RestAssured.port = url.getPort();
+    }
+
+    // ── Setup ─────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(0)
+    void setupCalendarWithWeekdayOnlyWindow() {
+        calendarId = given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "code": "slot-gen-test",
+                    "name": "Slot Generation Test Calendar",
+                    "autoSlotManager": false
+                }
+                """)
+            .when()
+            .post("/api/v1/miot-calendar/calendars")
+            .then()
+            .statusCode(201)
+            .extract()
+            .path("id");
+
+        // Weekdays only, 08:00–12:00 (exclusive end), 60-min slots
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "name": "Weekday Morning",
+                    "startHour": 8,
+                    "endHour": 12,
+                    "slotDurationMinutes": 60,
+                    "capacityPerSlot": 1,
+                    "daysOfWeek": "1,2,3,4,5",
+                    "validFrom": "%s"
+                }
+                """, LocalDate.now()))
+            .when()
+            .post("/api/v1/miot-calendar/calendars/" + calendarId + "/time-windows")
+            .then()
+            .statusCode(201);
+    }
+
+    // ── Bug 1: day-of-week filter ─────────────────────────────────────────
+
+    /**
+     * A MON–FRI window must produce zero slots for a Sunday.
+     * Before the fix, includesDay() used String.contains() with 3-letter codes
+     * against numeric values ("1,2,3,4,5") so it silently returned false for
+     * every day, yielding 0 slots even on weekdays.
+     */
+    @Test
+    @Order(1)
+    void weekdayWindowProducesZeroSlotsOnSunday() {
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format(SLOTS_GENERATE_BODY, calendarId, A_SUNDAY, A_SUNDAY))
+            .when()
+            .post(slotsGenerateUrl.toString())
+            .then()
+            .statusCode(200)
+            .body(SLOTS_CREATED, equalTo(0));
+    }
+
+    /**
+     * The same MON–FRI window must generate slots on a Monday.
+     * This verifies that the day-of-week filter correctly accepts weekdays.
+     */
+    @Test
+    @Order(2)
+    void weekdayWindowProducesSlotsOnMonday() {
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format(SLOTS_GENERATE_BODY, calendarId, A_MONDAY, A_MONDAY))
+            .when()
+            .post(slotsGenerateUrl.toString())
+            .then()
+            .statusCode(200)
+            .body(SLOTS_CREATED, greaterThan(0));
+    }
+
+    // ── Bug 2: exclusive endHour ──────────────────────────────────────────
+
+    /**
+     * An 08:00–12:00 window with 60-min slots must produce exactly 4 slots
+     * per day: 08:00, 09:00, 10:00, 11:00.
+     * Before the fix the loop condition `hour == endHour && minutes == 0`
+     * emitted a fifth slot at 12:00.
+     *
+     * The Monday was already generated by the previous test; re-generating
+     * must report slotsCreated=0 and slotsSkipped=4, confirming the exact count.
+     */
+    @Test
+    @Order(3)
+    void slotCountPerDayMatchesExclusiveEndHour() {
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format(SLOTS_GENERATE_BODY, calendarId, A_MONDAY, A_MONDAY))
+            .when()
+            .post(slotsGenerateUrl.toString())
+            .then()
+            .statusCode(200)
+            .body(SLOTS_CREATED, equalTo(0))
+            .body(SLOTS_SKIPPED, equalTo(4));   // exactly 4 slots exist, none at endHour
+    }
+
+    /**
+     * No slot at 12:00 must appear in the stored list for Monday.
+     * The four stored slots must be 08:00, 09:00, 10:00, 11:00.
+     */
+    @Test
+    @Order(4)
+    void noSlotExistsAtEndHour() {
+        given()
+            .queryParam("calendarId", calendarId)
+            .queryParam("startDate", A_MONDAY.toString())
+            .queryParam("endDate",   A_MONDAY.toString())
+            .when()
+            .get("/api/v1/miot-calendar/slots")
+            .then()
+            .statusCode(200)
+            .body("data.size()", equalTo(4))
+            .body("data.slotHour", everyItem(not(equalTo(12))))
+            .body("data.slotHour", containsInAnyOrder(8, 9, 10, 11));
+    }
+}

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/SlotManagerResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/SlotManagerResourceTest.java
@@ -1,5 +1,6 @@
 package com.microboxlabs.miot.calendar.resource;
 
+import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -21,6 +22,15 @@ class SlotManagerResourceTest {
 
     @TestHTTPResource
     URL url;
+
+    @TestHTTPEndpoint(SlotManagerResource.class)
+    @TestHTTPResource
+    URL slotManagersUrl;
+
+    private static final String DAYS_IN_ADVANCE = "daysInAdvance";
+    private static final String STATUS_SUCCESS   = "SUCCESS";
+    private static final String STATUS           = "status";
+    private static final String SIZE             = "size()";
 
     private String calendarId;
     private String managerId;
@@ -62,7 +72,7 @@ class SlotManagerResourceTest {
                     "endHour": 12,
                     "slotDurationMinutes": 60,
                     "capacityPerSlot": 2,
-                    "daysOfWeek": "MON,TUE,WED,THU,FRI,SAT,SUN",
+                    "daysOfWeek": "1,2,3,4,5,6,7",
                     "validFrom": "%s"
                 }
                 """, LocalDate.now().toString()))
@@ -88,12 +98,12 @@ class SlotManagerResourceTest {
                 }
                 """, calendarId))
             .when()
-            .post("/api/v1/miot-calendar/slot-managers")
+            .post(slotManagersUrl.toString())
             .then()
             .statusCode(201)
             .body("calendarId", equalTo(calendarId))
             .body("active", equalTo(true))
-            .body("daysInAdvance", equalTo(14))
+            .body(DAYS_IN_ADVANCE, equalTo(14))
             .body("batchDays", equalTo(7))
             .body("lastRunStatus", nullValue())
             .extract()
@@ -105,10 +115,10 @@ class SlotManagerResourceTest {
     void testListManagers() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/slot-managers")
+            .get(slotManagersUrl.toString())
             .then()
             .statusCode(200)
-            .body("size()", greaterThanOrEqualTo(1));
+            .body(SIZE, greaterThanOrEqualTo(1));
     }
 
     @Test
@@ -116,11 +126,11 @@ class SlotManagerResourceTest {
     void testGetManager() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .get(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(200)
             .body("id", equalTo(managerId))
-            .body("daysInAdvance", equalTo(14));
+            .body(DAYS_IN_ADVANCE, equalTo(14));
     }
 
     @Test
@@ -135,10 +145,10 @@ class SlotManagerResourceTest {
                 }
                 """)
             .when()
-            .put("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .put(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(200)
-            .body("daysInAdvance", equalTo(21))
+            .body(DAYS_IN_ADVANCE, equalTo(21))
             .body("batchDays", equalTo(3));
     }
 
@@ -149,12 +159,12 @@ class SlotManagerResourceTest {
     void testRunOneManager() {
         given()
             .when()
-            .post("/api/v1/miot-calendar/slot-managers/" + managerId + "/run")
+            .post(slotManagersUrl + "/" + managerId + "/run")
             .then()
             .statusCode(200)
             .body("managerId", equalTo(managerId))
             .body("triggeredBy", equalTo("API"))
-            .body("status", equalTo("SUCCESS"))
+            .body(STATUS, equalTo(STATUS_SUCCESS))
             .body("slotsCreated", greaterThan(0))
             .body("generatedFrom", notNullValue())
             .body("generatedThrough", notNullValue());
@@ -166,10 +176,10 @@ class SlotManagerResourceTest {
         // Running again immediately: already generated through the horizon
         given()
             .when()
-            .post("/api/v1/miot-calendar/slot-managers/" + managerId + "/run")
+            .post(slotManagersUrl + "/" + managerId + "/run")
             .then()
             .statusCode(200)
-            .body("status", equalTo("SKIPPED"));
+            .body(STATUS, equalTo("SKIPPED"));
     }
 
     @Test
@@ -177,10 +187,10 @@ class SlotManagerResourceTest {
     void testRunAll() {
         given()
             .when()
-            .post("/api/v1/miot-calendar/slot-managers/run")
+            .post(slotManagersUrl + "/run")
             .then()
             .statusCode(200)
-            .body("size()", greaterThanOrEqualTo(0)); // may be empty if soft-lock triggers
+            .body(SIZE, greaterThanOrEqualTo(0)); // may be empty if soft-lock triggers
     }
 
     // ── Reprocess ─────────────────────────────────────────────────────────
@@ -201,7 +211,7 @@ class SlotManagerResourceTest {
                 }
                 """, from, to))
             .when()
-            .put("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .put(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(200)
             .body("reprocessFrom", equalTo(from.toString()))
@@ -210,22 +220,22 @@ class SlotManagerResourceTest {
         // Trigger run — should use reprocess window and clear it on success
         given()
             .when()
-            .post("/api/v1/miot-calendar/slot-managers/" + managerId + "/run")
+            .post(slotManagersUrl + "/" + managerId + "/run")
             .then()
             .statusCode(200)
-            .body("status", equalTo("SUCCESS"))
+            .body(STATUS, equalTo(STATUS_SUCCESS))
             .body("generatedFrom",    equalTo(from.toString()))
             .body("generatedThrough", equalTo(to.toString()));
 
         // Reprocess fields should be cleared after successful run
         given()
             .when()
-            .get("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .get(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(200)
             .body("reprocessFrom", nullValue())
             .body("reprocessTo",   nullValue())
-            .body("lastRunStatus", equalTo("SUCCESS"));
+            .body("lastRunStatus", equalTo(STATUS_SUCCESS));
     }
 
     // ── Run history ───────────────────────────────────────────────────────
@@ -236,10 +246,10 @@ class SlotManagerResourceTest {
         given()
             .queryParam("limit", 10)
             .when()
-            .get("/api/v1/miot-calendar/slot-managers/" + managerId + "/runs")
+            .get(slotManagersUrl + "/" + managerId + "/runs")
             .then()
             .statusCode(200)
-            .body("size()", greaterThanOrEqualTo(1))
+            .body(SIZE, greaterThanOrEqualTo(1))
             .body("[0].managerId", equalTo(managerId));
     }
 
@@ -249,10 +259,10 @@ class SlotManagerResourceTest {
         given()
             .queryParam("limit", 50)
             .when()
-            .get("/api/v1/miot-calendar/slot-managers/runs")
+            .get(slotManagersUrl + "/runs")
             .then()
             .statusCode(200)
-            .body("size()", greaterThanOrEqualTo(1));
+            .body(SIZE, greaterThanOrEqualTo(1));
     }
 
     // ── Deactivate ────────────────────────────────────────────────────────
@@ -262,13 +272,13 @@ class SlotManagerResourceTest {
     void testDeactivateManager() {
         given()
             .when()
-            .delete("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .delete(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(204);
 
         given()
             .when()
-            .get("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .get(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(200)
             .body("active", equalTo(false));
@@ -287,7 +297,7 @@ class SlotManagerResourceTest {
                 }
                 """)
             .when()
-            .post("/api/v1/miot-calendar/slot-managers")
+            .post(slotManagersUrl.toString())
             .then()
             .statusCode(400);
     }
@@ -303,7 +313,7 @@ class SlotManagerResourceTest {
                 }
                 """)
             .when()
-            .post("/api/v1/miot-calendar/slot-managers")
+            .post(slotManagersUrl.toString())
             .then()
             .statusCode(400);
     }
@@ -320,7 +330,7 @@ class SlotManagerResourceTest {
                 }
                 """, calendarId))
             .when()
-            .post("/api/v1/miot-calendar/slot-managers")
+            .post(slotManagersUrl.toString())
             .then()
             .statusCode(400);
     }
@@ -337,7 +347,7 @@ class SlotManagerResourceTest {
                 }
                 """, LocalDate.now()))
             .when()
-            .put("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .put(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(400);
     }
@@ -347,7 +357,7 @@ class SlotManagerResourceTest {
     void testGetNonExistentManager() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/slot-managers/00000000-0000-0000-0000-000000000000")
+            .get(slotManagersUrl + "/00000000-0000-0000-0000-000000000000")
             .then()
             .statusCode(404);
     }
@@ -357,7 +367,7 @@ class SlotManagerResourceTest {
     void testRunNonExistentManager() {
         given()
             .when()
-            .post("/api/v1/miot-calendar/slot-managers/00000000-0000-0000-0000-000000000000/run")
+            .post(slotManagersUrl + "/00000000-0000-0000-0000-000000000000/run")
             .then()
             .statusCode(404);
     }

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/SlotResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/SlotResourceTest.java
@@ -1,5 +1,6 @@
 package com.microboxlabs.miot.calendar.resource;
 
+import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -25,6 +26,14 @@ class SlotResourceTest {
 
     @TestHTTPResource
     URL url;
+
+    @TestHTTPEndpoint(SlotResource.class)
+    @TestHTTPResource
+    URL slotsUrl;
+
+    @TestHTTPEndpoint(SlotResource.class)
+    @TestHTTPResource("generate")
+    URL slotsGenerateUrl;
 
     private String calendarId;
     private String slotId;
@@ -67,7 +76,7 @@ class SlotResourceTest {
                     "endHour": 17,
                     "slotDurationMinutes": 30,
                     "capacityPerSlot": 3,
-                    "daysOfWeek": "MON,TUE,WED,THU,FRI,SAT,SUN",
+                    "daysOfWeek": "1,2,3,4,5,6,7",
                     "validFrom": "%s"
                 }
                 """, LocalDate.now().toString()))
@@ -93,7 +102,7 @@ class SlotResourceTest {
                 }
                 """, calendarId, today, nextWeek))
             .when()
-            .post("/api/v1/miot-calendar/slots/generate")
+            .post(slotsGenerateUrl.toString())
             .then()
             .statusCode(200)
             .body("slotsCreated", greaterThan(0))
@@ -111,7 +120,7 @@ class SlotResourceTest {
             .queryParam("startDate", today.toString())
             .queryParam("endDate", nextWeek.toString())
             .when()
-            .get("/api/v1/miot-calendar/slots")
+            .get(slotsUrl.toString())
             .then()
             .statusCode(200)
             .body("data.size()", greaterThan(0))
@@ -125,7 +134,7 @@ class SlotResourceTest {
     void testGetSlot() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/slots/" + slotId)
+            .get(slotsUrl + "/" + slotId)
             .then()
             .statusCode(200)
             .body("id", equalTo(slotId));
@@ -142,7 +151,7 @@ class SlotResourceTest {
             .queryParam("endDate", today.plusDays(7).toString())
             .queryParam("available", true)
             .when()
-            .get("/api/v1/miot-calendar/slots")
+            .get(slotsUrl.toString())
             .then()
             .statusCode(200)
             .body("data.size()", greaterThan(0));
@@ -159,7 +168,7 @@ class SlotResourceTest {
                 }
                 """)
             .when()
-            .patch("/api/v1/miot-calendar/slots/" + slotId + "/status")
+            .patch(slotsUrl + "/" + slotId + "/status")
             .then()
             .statusCode(200)
             .body("status", equalTo("CLOSED"));
@@ -173,7 +182,7 @@ class SlotResourceTest {
                 }
                 """)
             .when()
-            .patch("/api/v1/miot-calendar/slots/" + slotId + "/status")
+            .patch(slotsUrl + "/" + slotId + "/status")
             .then()
             .statusCode(200)
             .body("status", equalTo("OPEN"));
@@ -183,7 +192,7 @@ class SlotResourceTest {
     void testListSlotsRequiresCalendarId() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/slots")
+            .get(slotsUrl.toString())
             .then()
             .statusCode(400);
     }
@@ -198,7 +207,7 @@ class SlotResourceTest {
                 }
                 """)
             .when()
-            .post("/api/v1/miot-calendar/slots/generate")
+            .post(slotsGenerateUrl.toString())
             .then()
             .statusCode(400);
     }


### PR DESCRIPTION
## Summary

- **Bug 1 (root cause):** `getDayOfWeekCode()` returned 3-letter codes (`"MON"`…`"SUN"`) while the API stores numeric codes (`"1"`–`"7"`). `includesDay()` used `String.contains()` so every date silently failed the filter — 0 slots created on every run regardless of configuration.
- **Bug 2:** The while-loop condition `hour == endHour && minutes == 0` treated `endHour` as inclusive, emitting an extra slot at 12:00 for an 08:00–12:00 window (5 slots instead of the documented 4).

Closes #9

## Changes

| File | Change |
|------|--------|
| `SlotGeneratorService` | `getDayOfWeekCode()` → `DayOfWeek.getValue()` (numeric); loop → `while (hour < endHour)` |
| `TimeWindow` | `includesDay()` uses split + exact token match; default `daysOfWeek` updated to `"1,2,3,4,5"` |
| `TimeWindowRequest` | Schema description restored to numeric format |
| `SlotGenerationTest` | New — 4 regression cases for both bugs |
| Existing tests | `daysOfWeek` fixtures updated to numeric format; hardcoded URI paths replaced with `@TestHTTPEndpoint` fields; repeated string literals extracted as constants |

## Test plan

- [x] `SlotGenerationTest` — weekday window yields 0 slots on Sunday, >0 on Monday
- [x] `SlotGenerationTest` — re-generate Monday → `slotsSkipped=4` (exact count)
- [x] `SlotGenerationTest` — listed Monday slots: size=4, hours ∈ {8,9,10,11}, none at 12
- [x] Full suite (66 tests) passes: `./mvnw test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed day-of-week filtering to correctly match weekday schedules (e.g., weekday windows now properly exclude Sundays).
  * Fixed end-hour boundary logic to exclude the end hour, ensuring accurate slot generation (e.g., an 08:00–12:00 window now generates exactly four 60-minute slots, not five).

* **Tests**
  * Added integration tests validating slot generation with corrected day-of-week and time boundary handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->