### PR TITLE
fix: trigger SlotManager immediately on calendar creation and time-window mutations

### DIFF
--- a/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
@@ -43,7 +43,7 @@ public class TimeWindow extends PanacheEntityBase {
     public Integer capacityPerSlot = 1;
 
     @Column(name = "days_of_week", length = 50)
-    public String daysOfWeek = "MON,TUE,WED,THU,FRI";
+    public String daysOfWeek = "1,2,3,4,5";
 
     @Column(name = "valid_from", nullable = false)
     public LocalDate validFrom;
@@ -97,6 +97,11 @@ public class TimeWindow extends PanacheEntityBase {
         if (daysOfWeek == null || daysOfWeek.isEmpty()) {
             return false;
         }
-        return daysOfWeek.contains(dayOfWeek);
+        for (String token : daysOfWeek.split(",")) {
+            if (token.trim().equals(dayOfWeek)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/SlotManagerTriggerEvent.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/SlotManagerTriggerEvent.java
@@ -1,0 +1,12 @@
+package com.microboxlabs.miot.calendar.model;
+
+import java.util.UUID;
+
+/**
+ * CDI event fired to trigger a slot manager run after a transaction commits.
+ *
+ * Observed by SlotManagerExecutor with TransactionPhase.AFTER_SUCCESS so the
+ * manager always runs after the originating transaction (calendar or time-window
+ * write) has been committed and is visible to the generator's queries.
+ */
+public record SlotManagerTriggerEvent(UUID managerId, String triggeredBy) {}

--- a/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
@@ -30,14 +30,14 @@ public class CalendarService {
     @Inject
     CalendarGroupService calendarGroupService;
 
-    @Inject
-    Event<SlotManagerTriggerEvent> slotManagerTrigger;
-
+    private final Event<SlotManagerTriggerEvent> slotManagerTrigger;
     private final SlotManagerService slotManagerService;
 
     @Inject
-    public CalendarService(SlotManagerService slotManagerService) {
+    public CalendarService(SlotManagerService slotManagerService,
+                           Event<SlotManagerTriggerEvent> slotManagerTrigger) {
         this.slotManagerService = slotManagerService;
+        this.slotManagerTrigger = slotManagerTrigger;
     }
 
     /**

--- a/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
@@ -3,14 +3,18 @@ package com.microboxlabs.miot.calendar.service;
 import com.microboxlabs.miot.calendar.entity.Calendar;
 import com.microboxlabs.miot.calendar.entity.CalendarGroup;
 import com.microboxlabs.miot.calendar.entity.Slot;
+import com.microboxlabs.miot.calendar.entity.SlotManager;
 import com.microboxlabs.miot.calendar.entity.TimeWindow;
 import com.microboxlabs.miot.calendar.model.CalendarRequest;
+import com.microboxlabs.miot.calendar.model.SlotManagerTriggerEvent;
 import com.microboxlabs.miot.calendar.model.TimeWindowRequest;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -25,6 +29,9 @@ public class CalendarService {
 
     @Inject
     CalendarGroupService calendarGroupService;
+
+    @Inject
+    Event<SlotManagerTriggerEvent> slotManagerTrigger;
 
     private final SlotManagerService slotManagerService;
 
@@ -100,7 +107,8 @@ public class CalendarService {
         // Auto-provision SlotManager (defaults to true when null)
         boolean autoSlotManager = request.autoSlotManager() == null || request.autoSlotManager();
         if (autoSlotManager) {
-            slotManagerService.createDefaultManager(calendar);
+            SlotManager manager = slotManagerService.createDefaultManager(calendar);
+            slotManagerTrigger.fire(new SlotManagerTriggerEvent(manager.id, "API"));
         }
 
         LOG.infof("Created calendar: %s (%s)", calendar.name, calendar.code);
@@ -222,14 +230,25 @@ public class CalendarService {
         timeWindow.endHour = request.endHour();
         timeWindow.slotDurationMinutes = request.slotDurationMinutes() != null ? request.slotDurationMinutes() : 30;
         timeWindow.capacityPerSlot = request.capacityPerSlot() != null ? request.capacityPerSlot() : 1;
-        timeWindow.daysOfWeek = request.daysOfWeek() != null ? request.daysOfWeek() : "MON,TUE,WED,THU,FRI";
+        timeWindow.daysOfWeek = request.daysOfWeek() != null ? request.daysOfWeek() : "1,2,3,4,5";
         timeWindow.validFrom = request.validFrom();
         timeWindow.validTo = request.validTo();
         timeWindow.active = request.active() != null ? request.active() : true;
 
         timeWindow.persist();
         LOG.infof("Created time window: %s for calendar %s", timeWindow.name, calendar.code);
-        
+
+        SlotManager manager = SlotManager.findByCalendarId(calendarId);
+        if (manager != null && Boolean.TRUE.equals(manager.active)) {
+            // If the manager already generated slots through a future date, force a
+            // reprocess so this new time window's slots are created for the full range.
+            if (manager.generatedThrough != null) {
+                manager.reprocessFrom = LocalDate.now();
+                manager.reprocessTo   = manager.generatedThrough;
+            }
+            slotManagerTrigger.fire(new SlotManagerTriggerEvent(manager.id, "API"));
+        }
+
         return timeWindow;
     }
 
@@ -272,6 +291,17 @@ public class CalendarService {
         }
 
         LOG.infof("Updated time window: %s", timeWindow.name);
+
+        SlotManager manager = SlotManager.findByCalendarId(timeWindow.calendar.id);
+        if (manager != null && Boolean.TRUE.equals(manager.active)) {
+            // Force a reprocess so updated schedule rules apply to already-generated dates.
+            if (manager.generatedThrough != null) {
+                manager.reprocessFrom = LocalDate.now();
+                manager.reprocessTo   = manager.generatedThrough;
+            }
+            slotManagerTrigger.fire(new SlotManagerTriggerEvent(manager.id, "API"));
+        }
+
         return timeWindow;
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/service/SlotGeneratorService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/SlotGeneratorService.java
@@ -59,7 +59,7 @@ public class SlotGeneratorService {
                 int hour = timeWindow.startHour;
                 int minutes = 0;
 
-                while (hour < timeWindow.endHour || (hour == timeWindow.endHour && minutes == 0)) {
+                while (hour < timeWindow.endHour) {
                     // Check if slot already exists
                     Slot existing = Slot.findByCalendarAndDateTime(calendarId, date, hour, minutes);
                     
@@ -97,17 +97,10 @@ public class SlotGeneratorService {
     }
 
     /**
-     * Convert DayOfWeek to string code
+     * Convert DayOfWeek to its ISO numeric string (1=Monday … 7=Sunday),
+     * matching the format stored by the API ("daysOfWeek": "1,2,3,4,5").
      */
     private String getDayOfWeekCode(DayOfWeek dayOfWeek) {
-        return switch (dayOfWeek) {
-            case MONDAY -> "MON";
-            case TUESDAY -> "TUE";
-            case WEDNESDAY -> "WED";
-            case THURSDAY -> "THU";
-            case FRIDAY -> "FRI";
-            case SATURDAY -> "SAT";
-            case SUNDAY -> "SUN";
-        };
+        return String.valueOf(dayOfWeek.getValue());
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/service/SlotManagerExecutor.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/SlotManagerExecutor.java
@@ -5,7 +5,10 @@ import com.microboxlabs.miot.calendar.entity.SlotManagerRun;
 import com.microboxlabs.miot.calendar.model.GenerateSlotsResponse;
 import com.microboxlabs.miot.calendar.model.RunStatus;
 import com.microboxlabs.miot.calendar.model.SlotManagerRunResponse;
+import com.microboxlabs.miot.calendar.model.SlotManagerTriggerEvent;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.TransactionPhase;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
@@ -138,6 +141,21 @@ public class SlotManagerExecutor {
         }
 
         return loadRunResponse(runId);
+    }
+
+    /**
+     * Runs a single slot manager after the originating write transaction commits.
+     *
+     * Fired by CalendarService when a SlotManager is auto-provisioned on calendar
+     * creation, or when a time window is created/updated.  Using AFTER_SUCCESS
+     * ensures the manager and time-window rows are visible to the generator's
+     * queries before we start generating slots.
+     */
+    void onSlotManagerTrigger(
+            @Observes(during = TransactionPhase.AFTER_SUCCESS) SlotManagerTriggerEvent event) {
+        LOG.infof("Slot manager trigger received for manager %s (triggered by: %s)",
+            event.managerId(), event.triggeredBy());
+        runManager(event.managerId(), event.triggeredBy());
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────

--- a/src/main/java/com/microboxlabs/miot/calendar/service/SlotManagerExecutor.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/SlotManagerExecutor.java
@@ -164,8 +164,8 @@ public class SlotManagerExecutor {
             event.managerId(), event.triggeredBy());
         try {
             runManager(event.managerId(), event.triggeredBy());
-        } catch (Throwable t) {
-            LOG.errorf(t, "Slot manager trigger failed for manager %s (triggered by: %s)",
+        } catch (Exception e) {
+            LOG.errorf(e, "Slot manager trigger failed for manager %s (triggered by: %s)",
                 event.managerId(), event.triggeredBy());
         }
     }

--- a/src/main/java/com/microboxlabs/miot/calendar/service/SlotManagerExecutor.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/SlotManagerExecutor.java
@@ -162,7 +162,12 @@ public class SlotManagerExecutor {
             @Observes(during = TransactionPhase.AFTER_SUCCESS) SlotManagerTriggerEvent event) {
         LOG.infof("Slot manager trigger received for manager %s (triggered by: %s)",
             event.managerId(), event.triggeredBy());
-        runManager(event.managerId(), event.triggeredBy());
+        try {
+            runManager(event.managerId(), event.triggeredBy());
+        } catch (Throwable t) {
+            LOG.errorf(t, "Slot manager trigger failed for manager %s (triggered by: %s)",
+                event.managerId(), event.triggeredBy());
+        }
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────

--- a/src/main/java/com/microboxlabs/miot/calendar/service/SlotManagerExecutor.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/SlotManagerExecutor.java
@@ -11,6 +11,7 @@ import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.TransactionPhase;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
 import org.jboss.logging.Logger;
 
 import java.time.LocalDate;
@@ -150,7 +151,13 @@ public class SlotManagerExecutor {
      * creation, or when a time window is created/updated.  Using AFTER_SUCCESS
      * ensures the manager and time-window rows are visible to the generator's
      * queries before we start generating slots.
+     *
+     * REQUIRES_NEW is necessary because Narayana keeps the committed transaction
+     * context associated with the thread during AFTER_SUCCESS notification.
+     * Without it, the REQUIRED methods inside runManager() attempt to join the
+     * already-inactive transaction and throw InactiveTransactionException.
      */
+    @Transactional(TxType.REQUIRES_NEW)
     void onSlotManagerTrigger(
             @Observes(during = TransactionPhase.AFTER_SUCCESS) SlotManagerTriggerEvent event) {
         LOG.infof("Slot manager trigger received for manager %s (triggered by: %s)",

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
@@ -28,6 +28,12 @@ class BookingResourceTest {
     @TestHTTPResource
     URL url;
 
+    @TestHTTPEndpoint(BookingResource.class)
+    @TestHTTPResource
+    URL bookingsUrl;
+
+    private static final String RESOURCE_ID = "%s";
+
     private String calendarId;
     private String bookingId;
     private LocalDate slotDate;
@@ -73,7 +79,7 @@ class BookingResourceTest {
                     "endHour": 17,
                     "slotDurationMinutes": 30,
                     "capacityPerSlot": 2,
-                    "daysOfWeek": "MON,TUE,WED,THU,FRI,SAT,SUN",
+                    "daysOfWeek": "1,2,3,4,5,6,7",
                     "validFrom": "%s"
                 }
                 """, LocalDate.now().toString()))
@@ -108,7 +114,7 @@ class BookingResourceTest {
                 {
                     "calendarId": "%s",
                     "resource": {
-                        "id": "SRV-001",
+                        "id": "%s",
                         "type": "SERVICE",
                         "label": "Acme Corp - Santiago to Valparaiso",
                         "data": {
@@ -124,12 +130,12 @@ class BookingResourceTest {
                         "minutes": %d
                     }
                 }
-                """, calendarId, slotDate, slotHour, slotMinutes))
+                """, calendarId, RESOURCE_ID, slotDate, slotHour, slotMinutes))
             .when()
-            .post("/api/v1/miot-calendar/bookings")
+            .post(bookingsUrl.toString())
             .then()
             .statusCode(201)
-            .body("resource.id", equalTo("SRV-001"))
+            .body("resource.id", equalTo(RESOURCE_ID))
             .body("resource.type", equalTo("SERVICE"))
             .body("createdBy", equalTo("test-user"))
             .extract()
@@ -144,11 +150,11 @@ class BookingResourceTest {
             .queryParam("startDate", slotDate.toString())
             .queryParam("endDate", slotDate.plusDays(7).toString())
             .when()
-            .get("/api/v1/miot-calendar/bookings")
+            .get(bookingsUrl.toString())
             .then()
             .statusCode(200)
             .body("data.size()", greaterThan(0))
-            .body("data[0].resource.id", equalTo("SRV-001"));
+            .body("data[0].resource.id", equalTo(RESOURCE_ID));
     }
 
     @Test
@@ -156,11 +162,11 @@ class BookingResourceTest {
     void testGetBooking() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/bookings/" + bookingId)
+            .get(bookingsUrl + "/" + bookingId)
             .then()
             .statusCode(200)
             .body("id", equalTo(bookingId))
-            .body("resource.id", equalTo("SRV-001"));
+            .body("resource.id", equalTo(RESOURCE_ID));
     }
 
     @Test
@@ -168,7 +174,7 @@ class BookingResourceTest {
     void testGetBookingsByResource() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/bookings/resource/SRV-001")
+            .get(bookingsUrl + "/resource/" + RESOURCE_ID)
             .then()
             .statusCode(200)
             .body("data.size()", greaterThan(0));
@@ -184,7 +190,7 @@ class BookingResourceTest {
                 {
                     "calendarId": "%s",
                     "resource": {
-                        "id": "SRV-001",
+                        "id": "%s",
                         "type": "SERVICE",
                         "label": "Duplicate booking"
                     },
@@ -194,9 +200,9 @@ class BookingResourceTest {
                         "minutes": %d
                     }
                 }
-                """, calendarId, slotDate, slotHour, slotMinutes))
+                """, calendarId, RESOURCE_ID, slotDate, slotHour, slotMinutes))
             .when()
-            .post("/api/v1/miot-calendar/bookings")
+            .post(bookingsUrl.toString())
             .then()
             .statusCode(409); // Conflict
     }
@@ -223,7 +229,7 @@ class BookingResourceTest {
                 }
                 """, calendarId, slotDate, slotHour, slotMinutes))
             .when()
-            .post("/api/v1/miot-calendar/bookings")
+            .post(bookingsUrl.toString())
             .then()
             .statusCode(201);
     }
@@ -250,7 +256,7 @@ class BookingResourceTest {
                 }
                 """, calendarId, slotDate, slotHour, slotMinutes))
             .when()
-            .post("/api/v1/miot-calendar/bookings")
+            .post(bookingsUrl.toString())
             .then()
             .statusCode(409); // Conflict - slot full
     }
@@ -260,14 +266,14 @@ class BookingResourceTest {
     void testCancelBooking() {
         given()
             .when()
-            .delete("/api/v1/miot-calendar/bookings/" + bookingId)
+            .delete(bookingsUrl + "/" + bookingId)
             .then()
             .statusCode(204);
 
         // Verify booking is gone
         given()
             .when()
-            .get("/api/v1/miot-calendar/bookings/" + bookingId)
+            .get(bookingsUrl + "/" + bookingId)
             .then()
             .statusCode(404);
     }
@@ -284,7 +290,7 @@ class BookingResourceTest {
                 }
                 """)
             .when()
-            .post("/api/v1/miot-calendar/bookings")
+            .post(bookingsUrl.toString())
             .then()
             .statusCode(400);
     }
@@ -293,7 +299,7 @@ class BookingResourceTest {
     void testBookingNotFound() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/bookings/00000000-0000-0000-0000-000000000000")
+            .get(bookingsUrl + "/00000000-0000-0000-0000-000000000000")
             .then()
             .statusCode(404);
     }

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
@@ -32,7 +32,7 @@ class BookingResourceTest {
     @TestHTTPResource
     URL bookingsUrl;
 
-    private static final String RESOURCE_ID = "%s";
+    private static final String RESOURCE_ID = "SRV-001";
 
     private String calendarId;
     private String bookingId;

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/SlotGenerationLifecycleTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/SlotGenerationLifecycleTest.java
@@ -1,0 +1,261 @@
+package com.microboxlabs.miot.calendar.resource;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.quarkus.test.common.http.TestHTTPResource;
+import org.junit.jupiter.api.*;
+
+import java.net.URL;
+import java.time.LocalDate;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * Integration tests for the slot-generation lifecycle introduced to fix
+ * https://github.com/microboxlabs/modulariot/issues/53.
+ *
+ * <p>Two gaps existed before the fix:
+ * <ol>
+ *   <li>A SlotManager provisioned via {@code autoSlotManager: true} never ran
+ *       immediately; slots only appeared after the hourly cron or a manual trigger.</li>
+ *   <li>Creating or updating a time window never triggered the SlotManager, so
+ *       changes were not immediately reflected in available slots.</li>
+ * </ol>
+ *
+ * <p>Each test uses a unique calendar code so tests remain independent even when
+ * the full suite shares the same Quarkus instance.
+ */
+@QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SlotGenerationLifecycleTest {
+
+    /** Inclusive start for slot queries — far enough in the past to cover validFrom. */
+    private static final LocalDate QUERY_FROM = LocalDate.now();
+    /** Exclusive end: default daysInAdvance is 30. */
+    private static final LocalDate QUERY_TO   = LocalDate.now().plusDays(30);
+
+    @TestHTTPResource
+    URL url;
+
+    @BeforeEach
+    void setupRestAssured() {
+        RestAssured.baseURI = url.toString();
+        RestAssured.port = url.getPort();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private String createCalendar(String code, boolean autoSlotManager) {
+        return given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "code": "%s",
+                    "name": "%s",
+                    "timezone": "America/Santiago",
+                    "autoSlotManager": %b
+                }
+                """, code, code, autoSlotManager))
+            .when()
+            .post("/api/v1/miot-calendar/calendars")
+            .then()
+            .statusCode(201)
+            .extract().path("id");
+    }
+
+    private String createTimeWindow(String calendarId, String daysOfWeek) {
+        return given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "name": "Lifecycle Test Window",
+                    "startHour": 9,
+                    "endHour": 11,
+                    "slotDurationMinutes": 60,
+                    "capacityPerSlot": 1,
+                    "daysOfWeek": "%s",
+                    "validFrom": "%s"
+                }
+                """, daysOfWeek, QUERY_FROM))
+            .when()
+            .post("/api/v1/miot-calendar/calendars/" + calendarId + "/time-windows")
+            .then()
+            .statusCode(201)
+            .extract().path("id");
+    }
+
+    private String createSlotManager(String calendarId) {
+        return given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "calendarId": "%s",
+                    "daysInAdvance": 30,
+                    "batchDays": 7
+                }
+                """, calendarId))
+            .when()
+            .post("/api/v1/miot-calendar/slot-managers")
+            .then()
+            .statusCode(201)
+            .extract().path("id");
+    }
+
+    private int slotCount(String calendarId) {
+        return given()
+            .queryParam("calendarId", calendarId)
+            .queryParam("startDate", QUERY_FROM.toString())
+            .queryParam("endDate",   QUERY_TO.toString())
+            .when()
+            .get("/api/v1/miot-calendar/slots")
+            .then()
+            .statusCode(200)
+            .extract().path("data.size()");
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    /**
+     * Full new-calendar setup flow: create calendar (autoSlotManager=true), then
+     * add a time window. Slots must exist immediately after the time-window POST
+     * without any manual trigger call.
+     *
+     * <p>Before the fix: the manager ran at calendar-creation time (0 slots — no
+     * time windows yet), advanced {@code generatedThrough}, and the subsequent
+     * time-window trigger was SKIPPED.  After the fix: the time-window trigger
+     * sets a reprocess range so the manager regenerates the full window.
+     */
+    @Test
+    void testSlotsExistImmediatelyAfterFullCalendarSetup() {
+        String calendarId = createCalendar("lc-full-setup", true);
+        createTimeWindow(calendarId, "1,2,3,4,5");   // weekdays, numeric codes
+
+        Assertions.assertTrue(slotCount(calendarId) > 0,
+            "Slots must be generated immediately after time-window creation");
+    }
+
+    /**
+     * When autoSlotManager=true but NO time window has been created yet, the
+     * calendar-creation trigger runs the manager immediately and gracefully
+     * returns zero slots (no time windows → nothing to generate).
+     */
+    @Test
+    void testCalendarCreationWithNoTimeWindowsProducesZeroSlots() {
+        String calendarId = createCalendar("lc-no-tw", true);
+
+        Assertions.assertEquals(0, slotCount(calendarId),
+            "No slots expected when calendar has no time windows");
+    }
+
+    /**
+     * Time-window creation must trigger the SlotManager even when the calendar
+     * was created with autoSlotManager=false and the manager was added afterwards
+     * via the REST API (which does not auto-trigger a run).
+     *
+     * <p>Sequence:
+     * <ol>
+     *   <li>Create calendar (autoSlotManager=false) — no manager, no trigger.</li>
+     *   <li>Create slot manager via API — persisted but never run.</li>
+     *   <li>Verify 0 slots — manager exists but hasn't executed.</li>
+     *   <li>POST time window — trigger fires → manager runs → slots generated.</li>
+     *   <li>Verify slots > 0.</li>
+     * </ol>
+     */
+    @Test
+    void testTimeWindowCreationTriggersSlotGeneration() {
+        String calendarId = createCalendar("lc-tw-create", false);
+        createSlotManager(calendarId);
+
+        Assertions.assertEquals(0, slotCount(calendarId),
+            "No slots expected before any time window is created");
+
+        createTimeWindow(calendarId, "1,2,3,4,5");
+
+        Assertions.assertTrue(slotCount(calendarId) > 0,
+            "Slots must be generated immediately after time-window POST");
+    }
+
+    /**
+     * Updating a time window must trigger the SlotManager to re-run.
+     *
+     * <p>Sequence:
+     * <ol>
+     *   <li>Create calendar (autoSlotManager=false).</li>
+     *   <li>POST time window — no manager yet → no trigger → 0 slots.</li>
+     *   <li>Create slot manager via API — persisted but not run.</li>
+     *   <li>Verify 0 slots.</li>
+     *   <li>PUT time window (extend to all days) — trigger fires → manager runs.</li>
+     *   <li>Verify slots > 0.</li>
+     * </ol>
+     */
+    @Test
+    void testTimeWindowUpdateTriggersSlotGeneration() {
+        String calendarId = createCalendar("lc-tw-update", false);
+        // No manager yet → createTimeWindow trigger guard returns early
+        String timeWindowId = createTimeWindow(calendarId, "1,2,3,4,5");
+
+        Assertions.assertEquals(0, slotCount(calendarId),
+            "No slots expected before slot manager is created");
+
+        createSlotManager(calendarId);
+
+        Assertions.assertEquals(0, slotCount(calendarId),
+            "No slots expected after manager created but not yet triggered");
+
+        // Update the time window — this must trigger the manager
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "daysOfWeek": "1,2,3,4,5,6,7"
+                }
+                """)
+            .when()
+            .put("/api/v1/miot-calendar/calendars/" + calendarId + "/time-windows/" + timeWindowId)
+            .then()
+            .statusCode(200);
+
+        Assertions.assertTrue(slotCount(calendarId) > 0,
+            "Slots must be generated immediately after time-window PUT");
+    }
+
+    /**
+     * When no daysOfWeek is supplied in the request, the API must store the
+     * ISO-numeric default "1,2,3,4,5" (Mon–Fri) so it matches the numeric codes
+     * produced by the slot generator.
+     *
+     * <p>Before the fix the default was the name-format string "MON,TUE,WED,THU,FRI"
+     * which never matched the generator's numeric day codes, causing every
+     * time window created without an explicit daysOfWeek to silently produce 0 slots.
+     */
+    @Test
+    void testDefaultDaysOfWeekIsStoredAsNumericCodes() {
+        String calendarId = createCalendar("lc-default-dow", false);
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "name": "Default Days Window",
+                    "startHour": 9,
+                    "endHour": 10,
+                    "slotDurationMinutes": 60,
+                    "validFrom": "%s"
+                }
+                """, QUERY_FROM))
+            .when()
+            .post("/api/v1/miot-calendar/calendars/" + calendarId + "/time-windows")
+            .then()
+            .statusCode(201);
+
+        given()
+            .when()
+            .get("/api/v1/miot-calendar/calendars/" + calendarId + "/time-windows")
+            .then()
+            .statusCode(200)
+            .body("[0].daysOfWeek", equalTo("1,2,3,4,5"));
+    }
+}

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/SlotGenerationTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/SlotGenerationTest.java
@@ -1,0 +1,196 @@
+package com.microboxlabs.miot.calendar.resource;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.*;
+
+import java.net.URL;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration tests for slot generation correctness.
+ *
+ * Covers two bugs fixed together:
+ *
+ *   Bug 1 – day-of-week filter was broken:
+ *     The API schema described numeric codes ("1,2,3,4,5") while the generator
+ *     produced 3-letter codes ("MON"…"SUN"). includesDay() used String.contains(),
+ *     so "1,2,3,4,5".contains("MON") == false — every date was silently skipped
+ *     and 0 slots were ever created.
+ *
+ *   Bug 2 – endHour was treated as inclusive:
+ *     The while-loop condition `hour < endHour || (hour == endHour && minutes == 0)`
+ *     emitted one extra slot AT endHour. For an 08:00–12:00 window with 60-min
+ *     slots the generator created 5 slots (8,9,10,11,12) instead of the documented
+ *     4 (8,9,10,11).
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SlotGenerationTest {
+
+    private static final String SLOTS_GENERATE_BODY = """
+            {
+                "calendarId": "%s",
+                "startDate": "%s",
+                "endDate":   "%s"
+            }
+            """;
+    private static final String SLOTS_CREATED  = "slotsCreated";
+    private static final String SLOTS_SKIPPED  = "slotsSkipped";
+
+    @TestHTTPResource
+    URL url;
+
+    @TestHTTPEndpoint(SlotResource.class)
+    @TestHTTPResource("generate")
+    URL slotsGenerateUrl;
+
+    private String calendarId;
+
+    // Use a fixed Sunday and the following Monday so that both dates are
+    // always >= today (validFrom) regardless of which day the suite runs.
+    private static final LocalDate A_SUNDAY =
+            LocalDate.now().with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+    private static final LocalDate A_MONDAY =
+            LocalDate.now().with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY));
+
+    @BeforeEach
+    void setupRestAssured() {
+        RestAssured.baseURI = url.toString();
+        RestAssured.port = url.getPort();
+    }
+
+    // ── Setup ─────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(0)
+    void setupCalendarWithWeekdayOnlyWindow() {
+        calendarId = given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "code": "slot-gen-test",
+                    "name": "Slot Generation Test Calendar",
+                    "autoSlotManager": false
+                }
+                """)
+            .when()
+            .post("/api/v1/miot-calendar/calendars")
+            .then()
+            .statusCode(201)
+            .extract()
+            .path("id");
+
+        // Weekdays only, 08:00–12:00 (exclusive end), 60-min slots
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "name": "Weekday Morning",
+                    "startHour": 8,
+                    "endHour": 12,
+                    "slotDurationMinutes": 60,
+                    "capacityPerSlot": 1,
+                    "daysOfWeek": "1,2,3,4,5",
+                    "validFrom": "%s"
+                }
+                """, LocalDate.now()))
+            .when()
+            .post("/api/v1/miot-calendar/calendars/" + calendarId + "/time-windows")
+            .then()
+            .statusCode(201);
+    }
+
+    // ── Bug 1: day-of-week filter ─────────────────────────────────────────
+
+    /**
+     * A MON–FRI window must produce zero slots for a Sunday.
+     * Before the fix, includesDay() used String.contains() with 3-letter codes
+     * against numeric values ("1,2,3,4,5") so it silently returned false for
+     * every day, yielding 0 slots even on weekdays.
+     */
+    @Test
+    @Order(1)
+    void weekdayWindowProducesZeroSlotsOnSunday() {
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format(SLOTS_GENERATE_BODY, calendarId, A_SUNDAY, A_SUNDAY))
+            .when()
+            .post(slotsGenerateUrl.toString())
+            .then()
+            .statusCode(200)
+            .body(SLOTS_CREATED, equalTo(0));
+    }
+
+    /**
+     * The same MON–FRI window must generate slots on a Monday.
+     * This verifies that the day-of-week filter correctly accepts weekdays.
+     */
+    @Test
+    @Order(2)
+    void weekdayWindowProducesSlotsOnMonday() {
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format(SLOTS_GENERATE_BODY, calendarId, A_MONDAY, A_MONDAY))
+            .when()
+            .post(slotsGenerateUrl.toString())
+            .then()
+            .statusCode(200)
+            .body(SLOTS_CREATED, greaterThan(0));
+    }
+
+    // ── Bug 2: exclusive endHour ──────────────────────────────────────────
+
+    /**
+     * An 08:00–12:00 window with 60-min slots must produce exactly 4 slots
+     * per day: 08:00, 09:00, 10:00, 11:00.
+     * Before the fix the loop condition `hour == endHour && minutes == 0`
+     * emitted a fifth slot at 12:00.
+     *
+     * The Monday was already generated by the previous test; re-generating
+     * must report slotsCreated=0 and slotsSkipped=4, confirming the exact count.
+     */
+    @Test
+    @Order(3)
+    void slotCountPerDayMatchesExclusiveEndHour() {
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format(SLOTS_GENERATE_BODY, calendarId, A_MONDAY, A_MONDAY))
+            .when()
+            .post(slotsGenerateUrl.toString())
+            .then()
+            .statusCode(200)
+            .body(SLOTS_CREATED, equalTo(0))
+            .body(SLOTS_SKIPPED, equalTo(4));   // exactly 4 slots exist, none at endHour
+    }
+
+    /**
+     * No slot at 12:00 must appear in the stored list for Monday.
+     * The four stored slots must be 08:00, 09:00, 10:00, 11:00.
+     */
+    @Test
+    @Order(4)
+    void noSlotExistsAtEndHour() {
+        given()
+            .queryParam("calendarId", calendarId)
+            .queryParam("startDate", A_MONDAY.toString())
+            .queryParam("endDate",   A_MONDAY.toString())
+            .when()
+            .get("/api/v1/miot-calendar/slots")
+            .then()
+            .statusCode(200)
+            .body("data.size()", equalTo(4))
+            .body("data.slotHour", everyItem(not(equalTo(12))))
+            .body("data.slotHour", containsInAnyOrder(8, 9, 10, 11));
+    }
+}

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/SlotManagerResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/SlotManagerResourceTest.java
@@ -1,5 +1,6 @@
 package com.microboxlabs.miot.calendar.resource;
 
+import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -21,6 +22,15 @@ class SlotManagerResourceTest {
 
     @TestHTTPResource
     URL url;
+
+    @TestHTTPEndpoint(SlotManagerResource.class)
+    @TestHTTPResource
+    URL slotManagersUrl;
+
+    private static final String DAYS_IN_ADVANCE = "daysInAdvance";
+    private static final String STATUS_SUCCESS   = "SUCCESS";
+    private static final String STATUS           = "status";
+    private static final String SIZE             = "size()";
 
     private String calendarId;
     private String managerId;
@@ -62,7 +72,7 @@ class SlotManagerResourceTest {
                     "endHour": 12,
                     "slotDurationMinutes": 60,
                     "capacityPerSlot": 2,
-                    "daysOfWeek": "MON,TUE,WED,THU,FRI,SAT,SUN",
+                    "daysOfWeek": "1,2,3,4,5,6,7",
                     "validFrom": "%s"
                 }
                 """, LocalDate.now().toString()))
@@ -88,12 +98,12 @@ class SlotManagerResourceTest {
                 }
                 """, calendarId))
             .when()
-            .post("/api/v1/miot-calendar/slot-managers")
+            .post(slotManagersUrl.toString())
             .then()
             .statusCode(201)
             .body("calendarId", equalTo(calendarId))
             .body("active", equalTo(true))
-            .body("daysInAdvance", equalTo(14))
+            .body(DAYS_IN_ADVANCE, equalTo(14))
             .body("batchDays", equalTo(7))
             .body("lastRunStatus", nullValue())
             .extract()
@@ -105,10 +115,10 @@ class SlotManagerResourceTest {
     void testListManagers() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/slot-managers")
+            .get(slotManagersUrl.toString())
             .then()
             .statusCode(200)
-            .body("size()", greaterThanOrEqualTo(1));
+            .body(SIZE, greaterThanOrEqualTo(1));
     }
 
     @Test
@@ -116,11 +126,11 @@ class SlotManagerResourceTest {
     void testGetManager() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .get(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(200)
             .body("id", equalTo(managerId))
-            .body("daysInAdvance", equalTo(14));
+            .body(DAYS_IN_ADVANCE, equalTo(14));
     }
 
     @Test
@@ -135,10 +145,10 @@ class SlotManagerResourceTest {
                 }
                 """)
             .when()
-            .put("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .put(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(200)
-            .body("daysInAdvance", equalTo(21))
+            .body(DAYS_IN_ADVANCE, equalTo(21))
             .body("batchDays", equalTo(3));
     }
 
@@ -149,12 +159,12 @@ class SlotManagerResourceTest {
     void testRunOneManager() {
         given()
             .when()
-            .post("/api/v1/miot-calendar/slot-managers/" + managerId + "/run")
+            .post(slotManagersUrl + "/" + managerId + "/run")
             .then()
             .statusCode(200)
             .body("managerId", equalTo(managerId))
             .body("triggeredBy", equalTo("API"))
-            .body("status", equalTo("SUCCESS"))
+            .body(STATUS, equalTo(STATUS_SUCCESS))
             .body("slotsCreated", greaterThan(0))
             .body("generatedFrom", notNullValue())
             .body("generatedThrough", notNullValue());
@@ -166,10 +176,10 @@ class SlotManagerResourceTest {
         // Running again immediately: already generated through the horizon
         given()
             .when()
-            .post("/api/v1/miot-calendar/slot-managers/" + managerId + "/run")
+            .post(slotManagersUrl + "/" + managerId + "/run")
             .then()
             .statusCode(200)
-            .body("status", equalTo("SKIPPED"));
+            .body(STATUS, equalTo("SKIPPED"));
     }
 
     @Test
@@ -177,10 +187,10 @@ class SlotManagerResourceTest {
     void testRunAll() {
         given()
             .when()
-            .post("/api/v1/miot-calendar/slot-managers/run")
+            .post(slotManagersUrl + "/run")
             .then()
             .statusCode(200)
-            .body("size()", greaterThanOrEqualTo(0)); // may be empty if soft-lock triggers
+            .body(SIZE, greaterThanOrEqualTo(0)); // may be empty if soft-lock triggers
     }
 
     // ── Reprocess ─────────────────────────────────────────────────────────
@@ -201,7 +211,7 @@ class SlotManagerResourceTest {
                 }
                 """, from, to))
             .when()
-            .put("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .put(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(200)
             .body("reprocessFrom", equalTo(from.toString()))
@@ -210,22 +220,22 @@ class SlotManagerResourceTest {
         // Trigger run — should use reprocess window and clear it on success
         given()
             .when()
-            .post("/api/v1/miot-calendar/slot-managers/" + managerId + "/run")
+            .post(slotManagersUrl + "/" + managerId + "/run")
             .then()
             .statusCode(200)
-            .body("status", equalTo("SUCCESS"))
+            .body(STATUS, equalTo(STATUS_SUCCESS))
             .body("generatedFrom",    equalTo(from.toString()))
             .body("generatedThrough", equalTo(to.toString()));
 
         // Reprocess fields should be cleared after successful run
         given()
             .when()
-            .get("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .get(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(200)
             .body("reprocessFrom", nullValue())
             .body("reprocessTo",   nullValue())
-            .body("lastRunStatus", equalTo("SUCCESS"));
+            .body("lastRunStatus", equalTo(STATUS_SUCCESS));
     }
 
     // ── Run history ───────────────────────────────────────────────────────
@@ -236,10 +246,10 @@ class SlotManagerResourceTest {
         given()
             .queryParam("limit", 10)
             .when()
-            .get("/api/v1/miot-calendar/slot-managers/" + managerId + "/runs")
+            .get(slotManagersUrl + "/" + managerId + "/runs")
             .then()
             .statusCode(200)
-            .body("size()", greaterThanOrEqualTo(1))
+            .body(SIZE, greaterThanOrEqualTo(1))
             .body("[0].managerId", equalTo(managerId));
     }
 
@@ -249,10 +259,10 @@ class SlotManagerResourceTest {
         given()
             .queryParam("limit", 50)
             .when()
-            .get("/api/v1/miot-calendar/slot-managers/runs")
+            .get(slotManagersUrl + "/runs")
             .then()
             .statusCode(200)
-            .body("size()", greaterThanOrEqualTo(1));
+            .body(SIZE, greaterThanOrEqualTo(1));
     }
 
     // ── Deactivate ────────────────────────────────────────────────────────
@@ -262,13 +272,13 @@ class SlotManagerResourceTest {
     void testDeactivateManager() {
         given()
             .when()
-            .delete("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .delete(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(204);
 
         given()
             .when()
-            .get("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .get(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(200)
             .body("active", equalTo(false));
@@ -287,7 +297,7 @@ class SlotManagerResourceTest {
                 }
                 """)
             .when()
-            .post("/api/v1/miot-calendar/slot-managers")
+            .post(slotManagersUrl.toString())
             .then()
             .statusCode(400);
     }
@@ -303,7 +313,7 @@ class SlotManagerResourceTest {
                 }
                 """)
             .when()
-            .post("/api/v1/miot-calendar/slot-managers")
+            .post(slotManagersUrl.toString())
             .then()
             .statusCode(400);
     }
@@ -320,7 +330,7 @@ class SlotManagerResourceTest {
                 }
                 """, calendarId))
             .when()
-            .post("/api/v1/miot-calendar/slot-managers")
+            .post(slotManagersUrl.toString())
             .then()
             .statusCode(400);
     }
@@ -337,7 +347,7 @@ class SlotManagerResourceTest {
                 }
                 """, LocalDate.now()))
             .when()
-            .put("/api/v1/miot-calendar/slot-managers/" + managerId)
+            .put(slotManagersUrl + "/" + managerId)
             .then()
             .statusCode(400);
     }
@@ -347,7 +357,7 @@ class SlotManagerResourceTest {
     void testGetNonExistentManager() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/slot-managers/00000000-0000-0000-0000-000000000000")
+            .get(slotManagersUrl + "/00000000-0000-0000-0000-000000000000")
             .then()
             .statusCode(404);
     }
@@ -357,7 +367,7 @@ class SlotManagerResourceTest {
     void testRunNonExistentManager() {
         given()
             .when()
-            .post("/api/v1/miot-calendar/slot-managers/00000000-0000-0000-0000-000000000000/run")
+            .post(slotManagersUrl + "/00000000-0000-0000-0000-000000000000/run")
             .then()
             .statusCode(404);
     }

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/SlotResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/SlotResourceTest.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -92,6 +93,9 @@ class SlotResourceTest {
         LocalDate today = LocalDate.now();
         LocalDate nextWeek = today.plusDays(7);
 
+        // With auto-generation now active, slots are created immediately when the
+        // time window is persisted. A subsequent explicit generate call for the same
+        // range must report the existing slots as skipped rather than re-creating them.
         given()
             .contentType(ContentType.JSON)
             .body(String.format("""
@@ -105,7 +109,8 @@ class SlotResourceTest {
             .post(slotsGenerateUrl.toString())
             .then()
             .statusCode(200)
-            .body("slotsCreated", greaterThan(0))
+            .body("slotsCreated", greaterThanOrEqualTo(0))
+            .body("slotsSkipped", greaterThan(0))
             .body("message", containsString("Generated"));
     }
 

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/SlotResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/SlotResourceTest.java
@@ -1,5 +1,6 @@
 package com.microboxlabs.miot.calendar.resource;
 
+import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -25,6 +26,14 @@ class SlotResourceTest {
 
     @TestHTTPResource
     URL url;
+
+    @TestHTTPEndpoint(SlotResource.class)
+    @TestHTTPResource
+    URL slotsUrl;
+
+    @TestHTTPEndpoint(SlotResource.class)
+    @TestHTTPResource("generate")
+    URL slotsGenerateUrl;
 
     private String calendarId;
     private String slotId;
@@ -67,7 +76,7 @@ class SlotResourceTest {
                     "endHour": 17,
                     "slotDurationMinutes": 30,
                     "capacityPerSlot": 3,
-                    "daysOfWeek": "MON,TUE,WED,THU,FRI,SAT,SUN",
+                    "daysOfWeek": "1,2,3,4,5,6,7",
                     "validFrom": "%s"
                 }
                 """, LocalDate.now().toString()))
@@ -93,7 +102,7 @@ class SlotResourceTest {
                 }
                 """, calendarId, today, nextWeek))
             .when()
-            .post("/api/v1/miot-calendar/slots/generate")
+            .post(slotsGenerateUrl.toString())
             .then()
             .statusCode(200)
             .body("slotsCreated", greaterThan(0))
@@ -111,7 +120,7 @@ class SlotResourceTest {
             .queryParam("startDate", today.toString())
             .queryParam("endDate", nextWeek.toString())
             .when()
-            .get("/api/v1/miot-calendar/slots")
+            .get(slotsUrl.toString())
             .then()
             .statusCode(200)
             .body("data.size()", greaterThan(0))
@@ -125,7 +134,7 @@ class SlotResourceTest {
     void testGetSlot() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/slots/" + slotId)
+            .get(slotsUrl + "/" + slotId)
             .then()
             .statusCode(200)
             .body("id", equalTo(slotId));
@@ -142,7 +151,7 @@ class SlotResourceTest {
             .queryParam("endDate", today.plusDays(7).toString())
             .queryParam("available", true)
             .when()
-            .get("/api/v1/miot-calendar/slots")
+            .get(slotsUrl.toString())
             .then()
             .statusCode(200)
             .body("data.size()", greaterThan(0));
@@ -159,7 +168,7 @@ class SlotResourceTest {
                 }
                 """)
             .when()
-            .patch("/api/v1/miot-calendar/slots/" + slotId + "/status")
+            .patch(slotsUrl + "/" + slotId + "/status")
             .then()
             .statusCode(200)
             .body("status", equalTo("CLOSED"));
@@ -173,7 +182,7 @@ class SlotResourceTest {
                 }
                 """)
             .when()
-            .patch("/api/v1/miot-calendar/slots/" + slotId + "/status")
+            .patch(slotsUrl + "/" + slotId + "/status")
             .then()
             .statusCode(200)
             .body("status", equalTo("OPEN"));
@@ -183,7 +192,7 @@ class SlotResourceTest {
     void testListSlotsRequiresCalendarId() {
         given()
             .when()
-            .get("/api/v1/miot-calendar/slots")
+            .get(slotsUrl.toString())
             .then()
             .statusCode(400);
     }
@@ -198,7 +207,7 @@ class SlotResourceTest {
                 }
                 """)
             .when()
-            .post("/api/v1/miot-calendar/slots/generate")
+            .post(slotsGenerateUrl.toString())
             .then()
             .statusCode(400);
     }

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/SlotResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/SlotResourceTest.java
@@ -18,7 +18,6 @@ import java.time.LocalDate;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -109,7 +108,7 @@ class SlotResourceTest {
             .post(slotsGenerateUrl.toString())
             .then()
             .statusCode(200)
-            .body("slotsCreated", greaterThanOrEqualTo(0))
+            .body("slotsCreated", equalTo(0))
             .body("slotsSkipped", greaterThan(0))
             .body("message", containsString("Generated"));
     }


### PR DESCRIPTION
## Summary

Backend fix for [microboxlabs/modulariot#53](https://github.com/microboxlabs/modulariot/issues/53). Closes #11.

- **SlotManager now runs immediately on calendar creation** (`autoSlotManager: true`) — no more waiting for the hourly cron.
- **Creating or updating a time window now triggers slot generation** — changes are reflected in available slots without a manual API call.
- **Fixed `daysOfWeek` default** — was `"MON,TUE,WED,THU,FRI"` (name format), now `"1,2,3,4,5"` (ISO-numeric), matching the slot generator.

## Mechanism

A lightweight CDI event (`SlotManagerTriggerEvent`) is fired inside each `@Transactional` service method. `SlotManagerExecutor` observes it with `@Observes(during = TransactionPhase.AFTER_SUCCESS)`:

- **After TX commits** → data is visible to the generator's queries.
- **Independent transactions** → a generation failure cannot roll back the calendar/time-window write.
- **Synchronous** → HTTP response is sent after slot generation, so slots exist when the client receives the 201.

For time-window mutations where `generatedThrough` was already set, `reprocessFrom/reprocessTo` is written in the same transaction before the event fires, so the manager re-covers the full committed range instead of being immediately SKIPPED.

## Test plan

- [x] New `SlotGenerationLifecycleTest` (`@QuarkusTest`, 5 integration tests)
  - Full calendar setup → slots exist after time-window POST
  - Calendar creation with no time windows → graceful zero slots
  - Time-window creation triggers isolated slot generation
  - Time-window update triggers slot regeneration
  - Default `daysOfWeek` stored as `"1,2,3,4,5"`
- [x] All existing test classes compile cleanly (`SlotGenerationTest`, `SlotManagerResourceTest`, `CalendarResourceTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic slot manager triggers after calendar/time-window changes, including immediate generation for auto-managed calendars.

* **Bug Fixes**
  * Slot generation excludes the end hour (no slot at end time).
  * Day-of-week matching fixed for robust numeric comparisons.

* **Changes**
  * Default daysOfWeek stored as numeric codes (1–7).

* **Tests**
  * New integration and unit tests covering slot generation lifecycle and day/end-hour behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->