### PR TITLE
feat: add optional task filter to Calendar

### DIFF
--- a/src/main/java/com/microboxlabs/miot/calendar/entity/Calendar.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/Calendar.java
@@ -2,10 +2,13 @@ package com.microboxlabs.miot.calendar.entity;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -41,6 +44,10 @@ public class Calendar extends PanacheEntityBase {
 
     @Column(name = "parallelism", nullable = false)
     public Integer parallelism = 1;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "filter", columnDefinition = "jsonb")
+    public Map<String, String> filter;
 
     @Column(name = "created_at", nullable = false)
     public ZonedDateTime createdAt;

--- a/src/main/java/com/microboxlabs/miot/calendar/model/CalendarRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/CalendarRequest.java
@@ -3,6 +3,8 @@ package com.microboxlabs.miot.calendar.model;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Request to create or update a calendar
@@ -31,9 +33,16 @@ public record CalendarRequest(
     @Schema(description = "List of group codes to assign. null = no change; [] = remove all; [\"code1\"] = replace all")
     List<String> groups,
 
+    @Schema(description = "Optional task filter map applied to client-side task lists tied to this calendar. " +
+        "null = no change; {} = clear; populated map = replace. Allowed keys: origin, destination.",
+        examples = {"{\"origin\":\"ANF\"}"})
+    Map<String, String> filter,
+
     @Schema(description = "Whether to auto-provision a default SlotManager on creation. Defaults to true when null.", defaultValue = "true")
     Boolean autoSlotManager
 ) {
+    public static final Set<String> ALLOWED_FILTER_KEYS = Set.of("origin", "destination");
+
     /**
      * Validate the calendar request
      */
@@ -46,6 +55,14 @@ public record CalendarRequest(
         }
         if (parallelism != null && parallelism < 1) {
             throw new IllegalArgumentException("Parallelism must be at least 1");
+        }
+        if (filter != null) {
+            for (String key : filter.keySet()) {
+                if (!ALLOWED_FILTER_KEYS.contains(key)) {
+                    throw new IllegalArgumentException(
+                        "Unknown filter key '" + key + "'. Allowed: " + ALLOWED_FILTER_KEYS);
+                }
+            }
         }
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/CalendarResponse.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/CalendarResponse.java
@@ -5,6 +5,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -42,6 +43,11 @@ public record CalendarResponse(
     @Schema(description = "Groups this calendar belongs to")
     List<CalendarGroupResponse> groups,
 
+    @Schema(description = "Optional task filter map applied to client-side task lists tied to this calendar. " +
+        "Keys are drawn from the allowed set (origin, destination).",
+        examples = {"{\"origin\":\"ANF\"}"})
+    Map<String, String> filter,
+
     @Schema(description = "Whether this calendar has a SlotManager provisioned")
     Boolean hasSlotManager
 ) {
@@ -63,6 +69,7 @@ public record CalendarResponse(
             calendar.createdAt,
             calendar.updatedAt,
             groupResponses,
+            calendar.filter,
             hasSlotManager
         );
     }

--- a/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
@@ -15,7 +15,9 @@ import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -98,6 +100,7 @@ public class CalendarService {
         calendar.timezone = request.timezone() != null ? request.timezone() : "America/Santiago";
         calendar.active = request.active() != null ? request.active() : true;
         calendar.parallelism = request.parallelism() != null ? request.parallelism() : 1;
+        calendar.filter = sanitizeFilter(request.filter());
 
         calendar.persist();
 
@@ -144,6 +147,10 @@ public class CalendarService {
             if (!request.groups().isEmpty()) {
                 resolveAndAssignGroups(calendar, request.groups());
             }
+        }
+
+        if (request.filter() != null) {
+            calendar.filter = sanitizeFilter(request.filter());
         }
 
         if (parallelismChanged) {
@@ -213,6 +220,23 @@ public class CalendarService {
         // Step 2: Delete the calendar (JPA cascade deletes TimeWindows; DB cascade deletes SlotManager+Runs+GroupMembers)
         calendar.delete();
         LOG.infof("Hard deleted calendar: %s (%s)", calendar.name, calendar.code);
+    }
+
+    /**
+     * Drop blank/null entries and detach from the request map. Returns null when nothing remains
+     * so the JSONB column stores SQL NULL instead of an empty object.
+     */
+    private Map<String, String> sanitizeFilter(Map<String, String> input) {
+        if (input == null || input.isEmpty()) {
+            return null;
+        }
+        Map<String, String> clean = new HashMap<>();
+        for (Map.Entry<String, String> e : input.entrySet()) {
+            if (e.getValue() != null && !e.getValue().isBlank()) {
+                clean.put(e.getKey(), e.getValue());
+            }
+        }
+        return clean.isEmpty() ? null : clean;
     }
 
     /**

--- a/src/main/resources/db/migration/V9__add_calendar_filter.sql
+++ b/src/main/resources/db/migration/V9__add_calendar_filter.sql
@@ -1,0 +1,11 @@
+-- V9: Add optional task filter to calendars
+-- Stores a JSONB map of filter criteria (e.g., {"origin":"ANF","destination":"ANF"})
+-- consumed by client UIs to constrain task lists tied to the calendar.
+-- Allowed keys are validated by the application; PostgreSQL only enforces shape.
+
+ALTER TABLE cld_calendars
+    ADD COLUMN filter JSONB;
+
+ALTER TABLE cld_calendars
+    ADD CONSTRAINT chk_cld_calendars_filter_object
+    CHECK (filter IS NULL OR jsonb_typeof(filter) = 'object');

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/CalendarResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/CalendarResourceTest.java
@@ -241,4 +241,130 @@ class CalendarResourceTest {
             .then()
             .statusCode(404);
     }
+
+    @Test
+    void testCreateCalendarWithFilter() {
+        String id = given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "code": "filter-create",
+                    "name": "Filter Create",
+                    "timezone": "America/Santiago",
+                    "filter": {"origin": "ANF", "destination": "SCL"}
+                }
+                """)
+            .when()
+            .post("/api/v1/miot-calendar/calendars")
+            .then()
+            .statusCode(201)
+            .body("filter.origin", equalTo("ANF"))
+            .body("filter.destination", equalTo("SCL"))
+            .extract()
+            .path("id");
+
+        given()
+            .when()
+            .get("/api/v1/miot-calendar/calendars/" + id)
+            .then()
+            .statusCode(200)
+            .body("filter.origin", equalTo("ANF"))
+            .body("filter.destination", equalTo("SCL"));
+    }
+
+    @Test
+    void testUpdateCalendarFilterReplaceAndClear() {
+        String id = given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "code": "filter-update",
+                    "name": "Filter Update",
+                    "timezone": "America/Santiago",
+                    "filter": {"origin": "ANF"}
+                }
+                """)
+            .when()
+            .post("/api/v1/miot-calendar/calendars")
+            .then()
+            .statusCode(201)
+            .extract()
+            .path("id");
+
+        // Replace
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "filter": {"destination": "VAL"} }
+                """)
+            .when()
+            .put("/api/v1/miot-calendar/calendars/" + id)
+            .then()
+            .statusCode(200)
+            .body("filter.origin", nullValue())
+            .body("filter.destination", equalTo("VAL"));
+
+        // Clear via empty object → null
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "filter": {} }
+                """)
+            .when()
+            .put("/api/v1/miot-calendar/calendars/" + id)
+            .then()
+            .statusCode(200)
+            .body("filter", nullValue());
+
+        // Omit field → no change (still null)
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "name": "Filter Update Renamed" }
+                """)
+            .when()
+            .put("/api/v1/miot-calendar/calendars/" + id)
+            .then()
+            .statusCode(200)
+            .body("name", equalTo("Filter Update Renamed"))
+            .body("filter", nullValue());
+    }
+
+    @Test
+    void testCreateCalendarRejectsUnknownFilterKey() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "code": "filter-bad-key",
+                    "name": "Filter Bad Key",
+                    "timezone": "UTC",
+                    "filter": {"carrier": "X"}
+                }
+                """)
+            .when()
+            .post("/api/v1/miot-calendar/calendars")
+            .then()
+            .statusCode(400);
+    }
+
+    @Test
+    void testCreateCalendarBlankFilterValueDropped() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "code": "filter-blank",
+                    "name": "Filter Blank",
+                    "timezone": "UTC",
+                    "filter": {"origin": "ANF", "destination": "  "}
+                }
+                """)
+            .when()
+            .post("/api/v1/miot-calendar/calendars")
+            .then()
+            .statusCode(201)
+            .body("filter.origin", equalTo("ANF"))
+            .body("filter.destination", nullValue());
+    }
 }


### PR DESCRIPTION
Closes #16

## Summary
- Adds nullable `filter` JSONB column to `cld_calendars` (V9 migration) with object-shape constraint.
- Exposes `filter` on `CalendarRequest` / `CalendarResponse`; backend validates an allowlist of keys (`origin`, `destination`).
- Wires the field through `CalendarService` create + update with the same null/empty/populated semantics as `groups`. Blank values are dropped before persist.

## Test plan
- [x] `./mvnw test -Dtest=CalendarResourceTest` — 16/16 (includes 4 new filter cases: create, replace+clear, unknown key rejected, blank value dropped)
- [x] `./mvnw test` — 90/90 full suite
- [x] Manual: POST a calendar with `filter: {"origin":"ANF"}` against a dev DB, GET it back, confirm round-trip
- [x] Manual: PUT with `filter: {}` and confirm column becomes NULL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar filtering now supported with origin and destination keys
  * Filters are optional and can be updated or cleared
  * Invalid filter entries are rejected with descriptive error messages

* **Tests**
  * Added comprehensive tests for filter creation, updates, and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->