### PR TITLE
fix(calendar): persist time window color

### DIFF
--- a/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
@@ -54,6 +54,9 @@ public class TimeWindow extends PanacheEntityBase {
     @Column(name = "active")
     public Boolean active = true;
 
+    @Column(name = "color", length = 32)
+    public String color;
+
     @Column(name = "created_at", nullable = false)
     public ZonedDateTime createdAt;
 

--- a/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowRequest.java
@@ -31,7 +31,10 @@ public record TimeWindowRequest(
     LocalDate validTo,
 
     @Schema(description = "Whether the time window is active", defaultValue = "true")
-    Boolean active
+    Boolean active,
+
+    @Schema(description = "UI color token for displaying this time window (e.g., \"emerald\", \"amber\")", examples = {"emerald"}, maxLength = 32)
+    String color
 ) {
     /**
      * Validate the time window request

--- a/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowResponse.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowResponse.java
@@ -45,6 +45,9 @@ public record TimeWindowResponse(
     @Schema(required = true, description = "Whether the time window is active")
     Boolean active,
 
+    @Schema(description = "UI color token for displaying this time window (e.g., \"emerald\", \"amber\")", examples = {"emerald"})
+    String color,
+
     @Schema(required = true, description = "Timestamp when the time window was created", format = "date-time")
     ZonedDateTime createdAt,
 
@@ -67,6 +70,7 @@ public record TimeWindowResponse(
             timeWindow.validFrom,
             timeWindow.validTo,
             timeWindow.active,
+            timeWindow.color,
             timeWindow.createdAt,
             timeWindow.updatedAt
         );

--- a/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
@@ -284,6 +284,7 @@ public class CalendarService {
         timeWindow.validFrom = request.validFrom();
         timeWindow.validTo = request.validTo();
         timeWindow.active = request.active() != null ? request.active() : true;
+        timeWindow.color = request.color();
 
         timeWindow.persist();
         LOG.infof("Created time window: %s for calendar %s", timeWindow.name, calendar.code);
@@ -321,6 +322,7 @@ public class CalendarService {
         if (request.validFrom() != null)  tw.validFrom = request.validFrom();
         if (request.validTo() != null)    tw.validTo = request.validTo();
         if (request.active() != null)     tw.active = request.active();
+        if (request.color() != null)      tw.color = request.color();
         return needsRecompute;
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
@@ -25,21 +25,22 @@ import java.util.UUID;
  * Service for calendar operations
  */
 @ApplicationScoped
+@SuppressWarnings("java:S3252") // Panache active-record requires static calls on the entity subclass
 public class CalendarService {
 
     private static final Logger LOG = Logger.getLogger(CalendarService.class);
 
-    @Inject
-    CalendarGroupService calendarGroupService;
-
+    private final CalendarGroupService calendarGroupService;
     private final Event<SlotManagerTriggerEvent> slotManagerTrigger;
     private final SlotManagerService slotManagerService;
 
     @Inject
     public CalendarService(SlotManagerService slotManagerService,
-                           Event<SlotManagerTriggerEvent> slotManagerTrigger) {
+                           Event<SlotManagerTriggerEvent> slotManagerTrigger,
+                           CalendarGroupService calendarGroupService) {
         this.slotManagerService = slotManagerService;
         this.slotManagerTrigger = slotManagerTrigger;
+        this.calendarGroupService = calendarGroupService;
     }
 
     /**
@@ -226,6 +227,7 @@ public class CalendarService {
      * Drop blank/null entries and detach from the request map. Returns null when nothing remains
      * so the JSONB column stores SQL NULL instead of an empty object.
      */
+    @SuppressWarnings("java:S1168") // intentional null so JPA writes SQL NULL to the JSONB filter column
     private Map<String, String> sanitizeFilter(Map<String, String> input) {
         if (input == null || input.isEmpty()) {
             return null;

--- a/src/main/resources/db/migration/V10__add_color_to_time_windows.sql
+++ b/src/main/resources/db/migration/V10__add_color_to_time_windows.sql
@@ -1,0 +1,6 @@
+-- V10: Add optional display color to time windows
+-- Stores a UI color token (e.g., "emerald", "amber"). Closed set is enforced
+-- by the client; the database stays permissive.
+
+ALTER TABLE cld_time_windows
+    ADD COLUMN color VARCHAR(32);


### PR DESCRIPTION
Closes #18

## Summary

- Add nullable `color VARCHAR(32)` column to `cld_time_windows` (Flyway `V10`)
- Surface `color` on the `TimeWindow` entity, `TimeWindowRequest`, and `TimeWindowResponse`
- Persist `color` on create and on partial-update via `CalendarService`

The frontend's time window color picker writes a token (`emerald`, `blue`, `amber`, …) that previously had nowhere to land. After this change the value round-trips through the API and survives a refresh.

Backend stays permissive — the closed set of color tokens is enforced by the UI; the database only stores the string. The frontend already falls back to `emerald` on unknown / `NULL` values, so existing rows render unchanged.

## Scope

Backend only (Phase 1). Follow-up work for the SDK types, the `modulariot` app's Zod schema, and the frontend mapper will land in separate PRs against `microboxlabs/modulariot` so each layer can be reviewed in isolation.

## Test plan

- [x] `./mvnw verify` passes
- [x] Flyway applies `V10` cleanly on a fresh database
- [x] `POST /calendars/{id}/time-windows` with `"color": "amber"` returns the color in the response
- [x] `PUT /time-windows/{id}` with only `{"color": "blue"}` updates the color and leaves other fields untouched
- [x] `GET /calendars/{id}/time-windows` returns `color: null` for rows created before the migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time windows now support custom color assignment, allowing you to set and modify colors when creating or updating time windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->