### PR TITLE
feat: add TimeWindow `kind` (WINDOW vs BLOCK) for temporal blockades

### DIFF
--- a/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
@@ -1,5 +1,6 @@
 package com.microboxlabs.miot.calendar.entity;
 
+import com.microboxlabs.miot.calendar.model.TimeWindowKind;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.persistence.*;
 
@@ -57,6 +58,10 @@ public class TimeWindow extends PanacheEntityBase {
     @Column(name = "color", length = 32)
     public String color;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "kind", nullable = false, length = 16)
+    public TimeWindowKind kind = TimeWindowKind.WINDOW;
+
     @Column(name = "created_at", nullable = false)
     public ZonedDateTime createdAt;
 
@@ -77,11 +82,23 @@ public class TimeWindow extends PanacheEntityBase {
     }
 
     /**
+     * Default slot step for BLOCK windows. Matches the planning grid cell size
+     * so a block paints continuous CLOSED cells across the configured range.
+     */
+    public static final int BLOCK_SLOT_DURATION_MINUTES = 30;
+
+    /**
      * Derive slot duration from the window duration and capacity model.
      * numberOfSlots = capacity / parallelism (integer division)
      * slotDuration  = windowMinutes / numberOfSlots (integer division, min 1)
+     *
+     * BLOCK windows have no meaningful capacity, so they use a fixed 30-min
+     * step to align with the planning grid.
      */
     public int computeSlotDurationMinutes() {
+        if (kind == TimeWindowKind.BLOCK) {
+            return BLOCK_SLOT_DURATION_MINUTES;
+        }
         int windowMinutes = (endHour - startHour) * 60;
         int numberOfSlots = capacity / calendar.parallelism;
         if (numberOfSlots <= 0) numberOfSlots = 1;

--- a/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowKind.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowKind.java
@@ -1,0 +1,18 @@
+package com.microboxlabs.miot.calendar.model;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(description = "Kind of time window", enumeration = {"WINDOW", "BLOCK"})
+public enum TimeWindowKind {
+    /**
+     * Bookable window with capacity. Slots are generated as OPEN.
+     */
+    WINDOW,
+
+    /**
+     * Non-bookable period (holiday, maintenance, manual closure). Slot
+     * generation produces CLOSED slots so the planning UI can render blocked
+     * cells, and bookings against those slots are rejected.
+     */
+    BLOCK
+}

--- a/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowRequest.java
@@ -34,10 +34,16 @@ public record TimeWindowRequest(
     Boolean active,
 
     @Schema(description = "UI color token for displaying this time window (e.g., \"emerald\", \"amber\")", examples = {"emerald"}, maxLength = 32)
-    String color
+    String color,
+
+    @Schema(description = "Discriminator: WINDOW (bookable, default) or BLOCK (non-bookable)", defaultValue = "WINDOW")
+    TimeWindowKind kind
 ) {
     /**
-     * Validate the time window request
+     * Validate the time window request.
+     *
+     * BLOCK windows accept null/0 capacity since they generate non-bookable
+     * slots; WINDOW windows still require capacity >= 1.
      */
     public void validate() {
         if (name == null || name.isBlank()) {
@@ -55,7 +61,7 @@ public record TimeWindowRequest(
         if (validTo != null && validTo.isBefore(validFrom)) {
             throw new IllegalArgumentException("Valid to date must be after valid from date");
         }
-        if (capacity != null && capacity < 1) {
+        if (kind != TimeWindowKind.BLOCK && capacity != null && capacity < 1) {
             throw new IllegalArgumentException("Capacity must be at least 1");
         }
     }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowRequest.java
@@ -61,8 +61,14 @@ public record TimeWindowRequest(
         if (validTo != null && validTo.isBefore(validFrom)) {
             throw new IllegalArgumentException("Valid to date must be after valid from date");
         }
-        if (kind != TimeWindowKind.BLOCK && capacity != null && capacity < 1) {
-            throw new IllegalArgumentException("Capacity must be at least 1");
+        if (capacity != null) {
+            if (kind == TimeWindowKind.BLOCK) {
+                if (capacity < 0) {
+                    throw new IllegalArgumentException("Capacity must be at least 0 for BLOCK windows");
+                }
+            } else if (capacity < 1) {
+                throw new IllegalArgumentException("Capacity must be at least 1");
+            }
         }
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowRequest.java
@@ -61,14 +61,16 @@ public record TimeWindowRequest(
         if (validTo != null && validTo.isBefore(validFrom)) {
             throw new IllegalArgumentException("Valid to date must be after valid from date");
         }
-        if (capacity != null) {
-            if (kind == TimeWindowKind.BLOCK) {
-                if (capacity < 0) {
-                    throw new IllegalArgumentException("Capacity must be at least 0 for BLOCK windows");
-                }
-            } else if (capacity < 1) {
-                throw new IllegalArgumentException("Capacity must be at least 1");
-            }
+        validateCapacity();
+    }
+
+    private void validateCapacity() {
+        if (capacity == null) {
+            return;
+        }
+        int min = kind == TimeWindowKind.BLOCK ? 0 : 1;
+        if (capacity < min) {
+            throw new IllegalArgumentException("Capacity must be at least " + min);
         }
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowResponse.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowResponse.java
@@ -48,6 +48,9 @@ public record TimeWindowResponse(
     @Schema(description = "UI color token for displaying this time window (e.g., \"emerald\", \"amber\")", examples = {"emerald"})
     String color,
 
+    @Schema(required = true, description = "Discriminator: WINDOW (bookable) or BLOCK (non-bookable)")
+    TimeWindowKind kind,
+
     @Schema(required = true, description = "Timestamp when the time window was created", format = "date-time")
     ZonedDateTime createdAt,
 
@@ -71,6 +74,7 @@ public record TimeWindowResponse(
             timeWindow.validTo,
             timeWindow.active,
             timeWindow.color,
+            timeWindow.kind,
             timeWindow.createdAt,
             timeWindow.updatedAt
         );

--- a/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
@@ -280,7 +280,10 @@ public class CalendarService {
         timeWindow.name = request.name();
         timeWindow.startHour = request.startHour();
         timeWindow.endHour = request.endHour();
-        timeWindow.capacity = request.capacity() != null ? request.capacity() : 1;
+        timeWindow.kind = request.kind() != null ? request.kind() : com.microboxlabs.miot.calendar.model.TimeWindowKind.WINDOW;
+        timeWindow.capacity = timeWindow.kind == com.microboxlabs.miot.calendar.model.TimeWindowKind.BLOCK
+            ? (request.capacity() != null ? request.capacity() : 0)
+            : (request.capacity() != null ? request.capacity() : 1);
         timeWindow.daysOfWeek = request.daysOfWeek() != null ? request.daysOfWeek() : "1,2,3,4,5";
         timeWindow.slotDurationMinutes = timeWindow.computeSlotDurationMinutes();
         timeWindow.validFrom = request.validFrom();
@@ -325,6 +328,7 @@ public class CalendarService {
         if (request.validTo() != null)    tw.validTo = request.validTo();
         if (request.active() != null)     tw.active = request.active();
         if (request.color() != null)      tw.color = request.color();
+        if (request.kind() != null)      { tw.kind = request.kind();           needsRecompute = true; }
         return needsRecompute;
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
@@ -7,6 +7,7 @@ import com.microboxlabs.miot.calendar.entity.SlotManager;
 import com.microboxlabs.miot.calendar.entity.TimeWindow;
 import com.microboxlabs.miot.calendar.model.CalendarRequest;
 import com.microboxlabs.miot.calendar.model.SlotManagerTriggerEvent;
+import com.microboxlabs.miot.calendar.model.TimeWindowKind;
 import com.microboxlabs.miot.calendar.model.TimeWindowRequest;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
@@ -280,10 +281,8 @@ public class CalendarService {
         timeWindow.name = request.name();
         timeWindow.startHour = request.startHour();
         timeWindow.endHour = request.endHour();
-        timeWindow.kind = request.kind() != null ? request.kind() : com.microboxlabs.miot.calendar.model.TimeWindowKind.WINDOW;
-        timeWindow.capacity = timeWindow.kind == com.microboxlabs.miot.calendar.model.TimeWindowKind.BLOCK
-            ? (request.capacity() != null ? request.capacity() : 0)
-            : (request.capacity() != null ? request.capacity() : 1);
+        timeWindow.kind = request.kind() != null ? request.kind() : TimeWindowKind.WINDOW;
+        timeWindow.capacity = resolveCapacity(request.capacity(), timeWindow.kind);
         timeWindow.daysOfWeek = request.daysOfWeek() != null ? request.daysOfWeek() : "1,2,3,4,5";
         timeWindow.slotDurationMinutes = timeWindow.computeSlotDurationMinutes();
         timeWindow.validFrom = request.validFrom();
@@ -315,6 +314,16 @@ public class CalendarService {
         LOG.infof("Updated time window: %s", timeWindow.name);
         triggerSlotManagerReprocess(timeWindow.calendar.id);
         return timeWindow;
+    }
+
+    /**
+     * Default capacity: WINDOW = 1, BLOCK = 0 (BLOCK rows carry no quota).
+     */
+    private static int resolveCapacity(Integer requested, TimeWindowKind kind) {
+        if (requested != null) {
+            return requested;
+        }
+        return kind == TimeWindowKind.BLOCK ? 0 : 1;
     }
 
     private boolean applyTimeWindowFields(TimeWindow tw, TimeWindowRequest request) {

--- a/src/main/java/com/microboxlabs/miot/calendar/service/SlotGeneratorService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/SlotGeneratorService.java
@@ -5,11 +5,13 @@ import com.microboxlabs.miot.calendar.entity.Slot;
 import com.microboxlabs.miot.calendar.entity.TimeWindow;
 import com.microboxlabs.miot.calendar.model.GenerateSlotsResponse;
 import com.microboxlabs.miot.calendar.model.SlotStatus;
+import com.microboxlabs.miot.calendar.model.TimeWindowKind;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
@@ -69,10 +71,13 @@ public class SlotGeneratorService {
                                       LocalDate date, int[] counts) {
         String dayOfWeek = String.valueOf(date.getDayOfWeek().getValue());
 
+        // BLOCK windows are processed last so they can override an OPEN slot
+        // already created by a colliding WINDOW (CLOSED wins).
         List<TimeWindow> validWindows = timeWindows.stream()
             .filter(tw -> tw.validFrom.compareTo(date) <= 0)
             .filter(tw -> tw.validTo == null || tw.validTo.compareTo(date) >= 0)
             .filter(tw -> tw.includesDay(dayOfWeek))
+            .sorted(Comparator.comparing(tw -> tw.kind == TimeWindowKind.BLOCK))
             .toList();
 
         for (TimeWindow timeWindow : validWindows) {
@@ -90,6 +95,14 @@ public class SlotGeneratorService {
             if (existing == null) {
                 createSlot(calendar, timeWindow, date, hour, minutes);
                 counts[0]++;
+            } else if (timeWindow.kind == TimeWindowKind.BLOCK
+                    && existing.status == SlotStatus.OPEN
+                    && existing.currentOccupancy == 0) {
+                // BLOCK overrides an unbooked OPEN slot left by a colliding window.
+                existing.status = SlotStatus.CLOSED;
+                existing.timeWindow = timeWindow;
+                existing.capacity = 0;
+                counts[1]++;
             } else {
                 counts[1]++;
             }
@@ -110,9 +123,15 @@ public class SlotGeneratorService {
         slot.slotDate = date;
         slot.slotHour = hour;
         slot.slotMinutes = minutes;
-        slot.capacity = calendar.parallelism;
-        slot.currentOccupancy = 0;
-        slot.status = SlotStatus.OPEN;
+        if (timeWindow.kind == TimeWindowKind.BLOCK) {
+            slot.capacity = 0;
+            slot.currentOccupancy = 0;
+            slot.status = SlotStatus.CLOSED;
+        } else {
+            slot.capacity = calendar.parallelism;
+            slot.currentOccupancy = 0;
+            slot.status = SlotStatus.OPEN;
+        }
         slot.persist();
     }
 }

--- a/src/main/resources/db/migration/V11__add_kind_to_time_windows.sql
+++ b/src/main/resources/db/migration/V11__add_kind_to_time_windows.sql
@@ -1,0 +1,27 @@
+-- V11: Add `kind` discriminator to time windows
+-- WINDOW (default) is the historical bookable window with capacity.
+-- BLOCK marks a non-bookable period: slot generation produces CLOSED slots
+-- so the planning UI can paint blocked cells, and bookings are rejected.
+
+ALTER TABLE cld_time_windows
+    ADD COLUMN kind VARCHAR(16) NOT NULL DEFAULT 'WINDOW'
+        CHECK (kind IN ('WINDOW', 'BLOCK'));
+
+COMMENT ON COLUMN cld_time_windows.kind IS
+    'WINDOW = bookable with capacity; BLOCK = non-bookable, generates CLOSED slots';
+
+-- BLOCK windows persist with capacity = 0 (no quota); BLOCK-derived slots
+-- inherit capacity = 0. The original `> 0` checks assumed every row was
+-- bookable, which no longer holds. Booking validation rejects CLOSED slots
+-- before capacity is read, so the relaxed check is safe.
+ALTER TABLE cld_time_windows
+    DROP CONSTRAINT IF EXISTS chk_cld_time_windows_capacity;
+
+ALTER TABLE cld_time_windows
+    ADD CONSTRAINT chk_cld_time_windows_capacity CHECK (capacity >= 0);
+
+ALTER TABLE cld_slots
+    DROP CONSTRAINT IF EXISTS cld_slots_capacity_check;
+
+ALTER TABLE cld_slots
+    ADD CONSTRAINT cld_slots_capacity_check CHECK (capacity >= 0);

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
@@ -304,4 +304,87 @@ class BookingResourceTest {
             .then()
             .statusCode(404);
     }
+
+    /**
+     * A booking against a slot covered by a BLOCK time window must be rejected
+     * with the SLOT_CLOSED error (BLOCK windows generate CLOSED slots, which
+     * BookingValidationService already refuses).
+     */
+    @Test
+    @Order(9)
+    void testBookingRejectedOnBlockSlot() {
+        // Fresh calendar so the BLOCK doesn't disturb sibling tests.
+        String blockedCalendarId = given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "code": "blocked-calendar",
+                    "name": "Blocked Calendar",
+                    "parallelism": 1
+                }
+                """)
+            .when()
+            .post("/api/v1/miot-calendar/calendars")
+            .then()
+            .statusCode(201)
+            .extract()
+            .path("id");
+
+        LocalDate blockDate = LocalDate.now().plusDays(2);
+        int dayOfWeek = blockDate.getDayOfWeek().getValue();
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "name": "Blocked Period",
+                    "kind": "BLOCK",
+                    "startHour": 10,
+                    "endHour": 12,
+                    "daysOfWeek": "%d",
+                    "validFrom": "%s"
+                }
+                """, dayOfWeek, LocalDate.now()))
+            .when()
+            .post("/api/v1/miot-calendar/calendars/" + blockedCalendarId + "/time-windows")
+            .then()
+            .statusCode(201);
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "calendarId": "%s",
+                    "startDate": "%s",
+                    "endDate": "%s"
+                }
+                """, blockedCalendarId, blockDate, blockDate))
+            .when()
+            .post("/api/v1/miot-calendar/slots/generate")
+            .then()
+            .statusCode(200);
+
+        given()
+            .contentType(ContentType.JSON)
+            .header("X-User-Id", "test-user")
+            .body(String.format("""
+                {
+                    "calendarId": "%s",
+                    "resource": {
+                        "id": "SRV-BLOCKED",
+                        "type": "SERVICE",
+                        "label": "Should fail"
+                    },
+                    "slot": {
+                        "date": "%s",
+                        "hour": 10,
+                        "minutes": 0
+                    }
+                }
+                """, blockedCalendarId, blockDate))
+            .when()
+            .post(bookingsUrl.toString())
+            .then()
+            .statusCode(409);
+    }
 }

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/SlotGenerationTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/SlotGenerationTest.java
@@ -192,4 +192,123 @@ class SlotGenerationTest {
             .body("data.slotHour", everyItem(not(equalTo(12))))
             .body("data.slotHour", containsInAnyOrder(8, 9, 10, 11));
     }
+
+    // ── BLOCK windows: temporal blockades persist as CLOSED slots ─────────
+
+    /**
+     * A BLOCK window is created without capacity and overlays the existing
+     * 08:00–12:00 WINDOW on the same Monday. After regeneration, the slots
+     * inside the block range must be CLOSED so the planning UI can paint
+     * them as blocked.
+     */
+    @Test
+    @Order(5)
+    void blockWindowProducesClosedSlots() {
+        // BLOCK 09:00–11:00 on weekdays — overlaps the 08:00–12:00 WINDOW.
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "name": "Maintenance",
+                    "kind": "BLOCK",
+                    "startHour": 9,
+                    "endHour": 11,
+                    "daysOfWeek": "1,2,3,4,5",
+                    "validFrom": "%s"
+                }
+                """, LocalDate.now()))
+            .when()
+            .post("/api/v1/miot-calendar/calendars/" + calendarId + "/time-windows")
+            .then()
+            .statusCode(201)
+            .body("kind", equalTo("BLOCK"));
+
+        // Re-run slot generation on Monday so the BLOCK overlays the existing
+        // OPEN slots (overwrite-on-collision in SlotGeneratorService).
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format(SLOTS_GENERATE_BODY, calendarId, A_MONDAY, A_MONDAY))
+            .when()
+            .post(slotsGenerateUrl.toString())
+            .then()
+            .statusCode(200);
+
+        // Slots at 09 and 10 must be CLOSED; 08 and 11 must remain OPEN.
+        given()
+            .queryParam("calendarId", calendarId)
+            .queryParam("startDate", A_MONDAY.toString())
+            .queryParam("endDate",   A_MONDAY.toString())
+            .when()
+            .get("/api/v1/miot-calendar/slots")
+            .then()
+            .statusCode(200)
+            .body("data.find { it.slotHour == 8 }.status",  equalTo("OPEN"))
+            .body("data.find { it.slotHour == 9 }.status",  equalTo("CLOSED"))
+            .body("data.find { it.slotHour == 10 }.status", equalTo("CLOSED"))
+            .body("data.find { it.slotHour == 11 }.status", equalTo("OPEN"));
+    }
+
+    /**
+     * A BLOCK window on a calendar with no overlapping WINDOW must still
+     * generate CLOSED slots over the BLOCK time range, so the UI has data
+     * to render even on otherwise-empty days.
+     */
+    @Test
+    @Order(6)
+    void blockWindowGeneratesClosedSlotsWithoutOverlappingWindow() {
+        // Fresh calendar so we can isolate the BLOCK behaviour.
+        String blockOnlyCalendarId = given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "code": "block-only-calendar",
+                    "name": "Block Only",
+                    "autoSlotManager": false
+                }
+                """)
+            .when()
+            .post("/api/v1/miot-calendar/calendars")
+            .then()
+            .statusCode(201)
+            .extract()
+            .path("id");
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "name": "Holiday",
+                    "kind": "BLOCK",
+                    "startHour": 13,
+                    "endHour": 15,
+                    "daysOfWeek": "1,2,3,4,5",
+                    "validFrom": "%s"
+                }
+                """, LocalDate.now()))
+            .when()
+            .post("/api/v1/miot-calendar/calendars/" + blockOnlyCalendarId + "/time-windows")
+            .then()
+            .statusCode(201);
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format(SLOTS_GENERATE_BODY, blockOnlyCalendarId, A_MONDAY, A_MONDAY))
+            .when()
+            .post(slotsGenerateUrl.toString())
+            .then()
+            .statusCode(200)
+            .body(SLOTS_CREATED, equalTo(4)); // 13:00, 13:30, 14:00, 14:30
+
+        given()
+            .queryParam("calendarId", blockOnlyCalendarId)
+            .queryParam("startDate", A_MONDAY.toString())
+            .queryParam("endDate",   A_MONDAY.toString())
+            .when()
+            .get("/api/v1/miot-calendar/slots")
+            .then()
+            .statusCode(200)
+            .body("data.size()", equalTo(4))
+            .body("data.status", everyItem(equalTo("CLOSED")))
+            .body("data.capacity", everyItem(equalTo(0)));
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a `kind` discriminator (`WINDOW` | `BLOCK`) to `TimeWindow` so the modulariot planning UI can persist temporal blockades end-to-end. Today blocks live only in browser state and disappear on reload.
- BLOCK windows carry no capacity; slot generation emits them as `CLOSED` slots with `capacity = 0`. Existing `BookingValidationService` rejection of `CLOSED` slots covers the booking guard with no extra surface.
- BLOCK windows are processed last in `SlotGeneratorService`; on collision with an unbooked `OPEN` slot the BLOCK wins (status flipped to `CLOSED`, capacity zeroed) so blockades override windows.
- Migration `V11` adds the column with `DEFAULT 'WINDOW'` and relaxes `chk_cld_time_windows_capacity` and `cld_slots_capacity_check` to `>= 0`.

## Why not `capacity = 0`?

Considered before deciding on a first-class `kind`:
- `TimeWindowRequest.validate()` rejects `capacity < 1`.
- `TimeWindow.computeSlotDurationMinutes` does `capacity / parallelism`, so a zero-capacity window emits zero slots — there is nothing for the UI to paint as blocked. Blocks have to positively exist as data.

## Out of scope (follow-up phases)

- `miot-calendar-client` TS package: expose `kind` on `TimeWindowRequest`/`TimeWindowResponse` and bump the version.
- `modulariot/turbo-repo` frontend: stop dropping blocks in `saveLocalWindows`; round-trip `kind` through `localToApiTimeWindow` / `apiToLocalTimeWindow`.

## Test plan

- [x] `./mvnw test` — 93/93 pass (90 prior + 3 new).
- [x] New `SlotGenerationTest.blockWindowProducesClosedSlots` — BLOCK overlaying a WINDOW flips collided OPEN slots to CLOSED.
- [x] New `SlotGenerationTest.blockWindowGeneratesClosedSlotsWithoutOverlappingWindow` — BLOCK on a clean calendar emits CLOSED slots with `capacity=0`.
- [x] New `BookingResourceTest.testBookingRejectedOnBlockSlot` — `POST /bookings` against a BLOCK slot returns `409`.
- [x] Manual: create a BLOCK time window via Bruno, regenerate slots, confirm `GET /slots` returns `status=CLOSED` rows over the configured range.

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added time window types: "WINDOW" for standard bookable periods and "BLOCK" for unavailable reservations that cannot be booked.

* **Improvements**
  * Block-type windows now generate closed time slots with fixed duration and zero capacity.
  * Slot generation prioritizes block-type windows, allowing them to override conflicting open slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->