### PR TITLE
[codex] Preserve slot capacity remainders

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,12 @@ curl -X POST http://localhost:8083/api/v1/miot-calendar/calendars/{calendarId}/t
 ```
 
 The `capacity` is the total number of services this window can handle. Slot duration is derived automatically:
-- `numberOfSlots = max(1, floor(capacity / parallelism))` — clamped to 1 when capacity < parallelism
+- `numberOfSlots = max(1, ceil(capacity / parallelism))`
 - `slotDuration = windowMinutes / numberOfSlots`
-- `slot.capacity = parallelism`
+- `slot.capacity = min(parallelism, remaining window capacity)` — the final slot may carry the remainder
 
 Example: 8-hour window (480 min), capacity=20, parallelism=5 → 4 slots of 120 min, each with capacity=5.
-If capacity < parallelism (e.g., capacity=2, parallelism=5), a single slot spans the entire window with capacity=5.
+If capacity < parallelism (e.g., capacity=2, parallelism=5), a single slot spans the entire window with capacity=2.
 
 Days of week use ISO numeric codes: 1=Monday through 7=Sunday.
 

--- a/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
@@ -89,7 +89,7 @@ public class TimeWindow extends PanacheEntityBase {
 
     /**
      * Derive slot duration from the window duration and capacity model.
-     * numberOfSlots = capacity / parallelism (integer division)
+     * numberOfSlots = ceil(capacity / parallelism)
      * slotDuration  = windowMinutes / numberOfSlots (integer division, min 1)
      *
      * BLOCK windows have no meaningful capacity, so they use a fixed 30-min
@@ -100,10 +100,36 @@ public class TimeWindow extends PanacheEntityBase {
             return BLOCK_SLOT_DURATION_MINUTES;
         }
         int windowMinutes = (endHour - startHour) * 60;
-        int numberOfSlots = capacity / calendar.parallelism;
-        if (numberOfSlots <= 0) numberOfSlots = 1;
+        int numberOfSlots = computeNumberOfSlots();
         int duration = windowMinutes / numberOfSlots;
         return Math.max(duration, 1);
+    }
+
+    /**
+     * Number of bookable slots needed to represent the full window capacity.
+     */
+    public int computeNumberOfSlots() {
+        if (kind == TimeWindowKind.BLOCK) {
+            return 0;
+        }
+        int parallelism = Math.max(calendar.parallelism, 1);
+        return Math.max((capacity + parallelism - 1) / parallelism, 1);
+    }
+
+    /**
+     * Capacity for a generated slot at the given zero-based position.
+     * Full slots use calendar parallelism; the final slot may carry the remainder.
+     */
+    public int computeSlotCapacity(int slotIndex) {
+        if (kind == TimeWindowKind.BLOCK) {
+            return 0;
+        }
+        int parallelism = Math.max(calendar.parallelism, 1);
+        int remaining = capacity - (slotIndex * parallelism);
+        if (remaining <= 0) {
+            return 0;
+        }
+        return Math.min(parallelism, remaining);
     }
 
     // Finder methods

--- a/src/main/java/com/microboxlabs/miot/calendar/service/SlotGeneratorService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/SlotGeneratorService.java
@@ -89,11 +89,15 @@ public class SlotGeneratorService {
                                         LocalDate date, int[] counts) {
         int hour = timeWindow.startHour;
         int minutes = 0;
+        int slotIndex = 0;
+        int maxSlots = timeWindow.kind == TimeWindowKind.BLOCK
+                ? Integer.MAX_VALUE
+                : timeWindow.computeNumberOfSlots();
 
-        while (hour < timeWindow.endHour) {
+        while (hour < timeWindow.endHour && slotIndex < maxSlots) {
             Slot existing = Slot.findByCalendarAndDateTime(calendar.id, date, hour, minutes);
             if (existing == null) {
-                createSlot(calendar, timeWindow, date, hour, minutes);
+                createSlot(calendar, timeWindow, date, hour, minutes, slotIndex);
                 counts[0]++;
             } else if (timeWindow.kind == TimeWindowKind.BLOCK
                     && existing.status == SlotStatus.OPEN
@@ -112,11 +116,12 @@ public class SlotGeneratorService {
                 hour += minutes / 60;
                 minutes = minutes % 60;
             }
+            slotIndex++;
         }
     }
 
     private void createSlot(Calendar calendar, TimeWindow timeWindow,
-                            LocalDate date, int hour, int minutes) {
+                            LocalDate date, int hour, int minutes, int slotIndex) {
         Slot slot = new Slot();
         slot.calendar = calendar;
         slot.timeWindow = timeWindow;
@@ -128,7 +133,7 @@ public class SlotGeneratorService {
             slot.currentOccupancy = 0;
             slot.status = SlotStatus.CLOSED;
         } else {
-            slot.capacity = calendar.parallelism;
+            slot.capacity = timeWindow.computeSlotCapacity(slotIndex);
             slot.currentOccupancy = 0;
             slot.status = SlotStatus.OPEN;
         }

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/ParallelismCapacityTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/ParallelismCapacityTest.java
@@ -235,14 +235,14 @@ class ParallelismCapacityTest {
     }
 
     /**
-     * Verify floor behavior: parallelism=3, capacity=10, 4-hour window.
-     * numberOfSlots = 10 / 3 = 3 (integer division)
-     * slotDuration  = 240 / 3 = 80min
-     * slot.capacity = 3
-     * actualTotal   = 3 * 3 = 9 (≤ requested 10)
+     * Verify remainder behavior: parallelism=3, capacity=10, 4-hour window.
+     * numberOfSlots = ceil(10 / 3) = 4
+     * slotDuration  = 240 / 4 = 60min
+     * slot.capacity = 3, 3, 3, 1
+     * actualTotal   = 10
      */
     @Test
-    void testFloorBehaviorWithUnevenDivision() {
+    void testRemainderCapacityWithUnevenDivision() {
         String calendarId = createCalendar("par-floor-div", 3);
         createTimeWindow(calendarId, 8, 12, 10);
 
@@ -254,8 +254,8 @@ class ParallelismCapacityTest {
             .get(SLOTS_PATH)
             .then()
             .statusCode(200)
-            .body("data.size()", equalTo(3))
-            .body("data.every { it.capacity == 3 }", equalTo(true));
+            .body("data.size()", equalTo(4))
+            .body("data.capacity", contains(3, 3, 3, 1));
     }
 
     /**

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/ParallelismEdgeCaseTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/ParallelismEdgeCaseTest.java
@@ -521,9 +521,8 @@ class ParallelismEdgeCaseTest {
         LocalDate futureWeekday = LocalDate.now().plusDays(45)
                 .with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY));
 
-        // Newly generated slots should have capacity=3
-        // (parallelism=3, capacity=2 → numberOfSlots=2/3=0→1, slotDuration=120min, capacity=3)
-        // Actually: capacity=2/parallelism=3 → numberOfSlots=0→1 slot, duration=120min, capacity=3
+        // Newly generated slots should preserve the window capacity.
+        // parallelism=3, capacity=2 → one slot, duration=120min, capacity=2
         List<Object> slots = getSlots(calendarId, futureWeekday);
         Assertions.assertFalse(slots.isEmpty(),
                 "Expected slots on a future weekday within extended range");
@@ -536,7 +535,8 @@ class ParallelismEdgeCaseTest {
             .get(SLOTS_PATH)
             .then()
             .statusCode(200)
-            .body("data.every { it.capacity == 3 }", equalTo(true));
+            .body("data.size()", equalTo(1))
+            .body("data[0].capacity", equalTo(2));
     }
 
     // ── Group 5: Concurrency ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #22.

This updates slot generation so a time window's configured total capacity is preserved when capacity is not evenly divisible by calendar parallelism.

## What changed

- Use ceiling division to compute the number of bookable slots needed for a time window.
- Cap each generated slot to the remaining unallocated window capacity, so the last slot can carry a remainder.
- Stop generating bookable slots once the configured window capacity has been fully allocated.
- Update README documentation for the corrected capacity model.
- Update parallelism tests for uneven division and capacity-less-than-parallelism scenarios.

## Root cause

The previous model used floor division for `capacity / parallelism` and assigned every slot `calendar.parallelism`. For example, capacity 3 with parallelism 2 generated one slot with capacity 2, dropping one unit of capacity.

## Validation

- `./mvnw test -Dtest=ParallelismCapacityTest,ParallelismEdgeCaseTest`
- `./mvnw test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated calendar slot capacity allocation to use ceiling-based division instead of floor division when capacity doesn't divide evenly by parallelism. The remainder capacity is now properly distributed to the final slot, improving accuracy and ensuring fairer capacity distribution across all available booking slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->