### PR TITLE
feat: PUT /bookings/{id} — update booking resource data in place

### DIFF
--- a/bruno/Bookings/Update Booking.bru
+++ b/bruno/Bookings/Update Booking.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Update Booking
+  type: http
+  seq: 6
+}
+
+put {
+  url: {{baseUrl}}/api/v1/miot-calendar/bookings/{{bookingId}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "resource": {
+      "id": "truck-4521",
+      "type": "truck",
+      "label": "Truck AB-1234 (assigned)",
+      "data": {
+        "driver": "Juan Pérez",
+        "plate": "AB-1234",
+        "assignedCarrier": "carrier-uuid"
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microboxlabs</groupId>
     <artifactId>miot-calendar</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <packaging>jar</packaging>
 
     <name>MIOT Calendar</name>

--- a/src/main/java/com/microboxlabs/miot/calendar/model/BookingUpdateRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/BookingUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.microboxlabs.miot.calendar.model;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * Request to update an existing booking's resource payload in place.
+ * The slot is not changed by this operation; moving a booking to another
+ * slot is done via cancel + create.
+ */
+@Schema(description = "Request payload to update a booking's resource data in place")
+public record BookingUpdateRequest(
+    @Schema(required = true, description = "Resource payload to store on the booking")
+    ResourceData resource
+) {
+    /**
+     * Validate the update request
+     */
+    public void validate() {
+        if (resource == null) {
+            throw new IllegalArgumentException("Resource is required");
+        }
+        resource.validate();
+    }
+}

--- a/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
@@ -101,6 +101,39 @@ public class BookingResource {
         }
     }
 
+    @PUT
+    @Path("/{id}")
+    @Transactional
+    @Operation(operationId = "updateBooking", summary = "Update booking resource data", description = "Update an existing booking's resource payload in place. The slot is not changed; move a booking by cancelling and recreating it.")
+    @APIResponse(responseCode = "200", description = "Booking updated",
+        content = @Content(schema = @Schema(implementation = BookingResponse.class)))
+    @APIResponse(responseCode = "400", description = "Invalid request (e.g. missing resource or resource id mismatch)",
+        content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @APIResponse(responseCode = "404", description = "Booking not found",
+        content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    public Response updateBooking(
+            @Parameter(description = "Unique identifier of the booking to update", required = true) @PathParam("id") UUID id,
+            BookingUpdateRequest request) {
+        try {
+            if (request == null) {
+                throw new IllegalArgumentException("Request body is required");
+            }
+            request.validate();
+            Booking booking = bookingService.updateBookingResource(id, request.resource());
+            return Response.ok(BookingResponse.from(booking)).build();
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage() != null && e.getMessage().startsWith("Booking not found")) {
+                return Response.status(Response.Status.NOT_FOUND)
+                    .entity(ErrorResponse.notFound(e.getMessage()))
+                    .build();
+            }
+            LOG.warnf("Invalid booking update request: %s", e.getMessage());
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(ErrorResponse.badRequest(e.getMessage()))
+                .build();
+        }
+    }
+
     @DELETE
     @Path("/{id}")
     @Transactional

--- a/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
@@ -4,6 +4,7 @@ import com.microboxlabs.miot.calendar.entity.Booking;
 import com.microboxlabs.miot.calendar.entity.Calendar;
 import com.microboxlabs.miot.calendar.entity.Slot;
 import com.microboxlabs.miot.calendar.model.BookingRequest;
+import com.microboxlabs.miot.calendar.model.ResourceData;
 import com.microboxlabs.miot.calendar.validation.BookingValidationService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -104,6 +105,38 @@ public class BookingService {
 
         LOG.infof("Created booking %s for resource %s in slot %s",
             booking.id, booking.resourceId, slot.id);
+
+        return booking;
+    }
+
+    /**
+     * Update an existing booking's resource payload in place.
+     *
+     * <p>Only {@code resourceType}, {@code resourceLabel} and {@code resourceData}
+     * change — the slot stays the same. The request's resource id must match the
+     * booking's current resource id; a booking cannot be repointed to a different
+     * resource (use cancel + create for that).
+     */
+    @Transactional
+    public Booking updateBookingResource(UUID bookingId, ResourceData resource) {
+        Booking booking = Booking.findById(bookingId);
+        if (booking == null) {
+            throw new IllegalArgumentException("Booking not found: " + bookingId);
+        }
+
+        resource.validate();
+        if (!resource.id().equals(booking.resourceId)) {
+            throw new IllegalArgumentException(String.format(
+                "Resource id mismatch: booking %s is for resource %s, cannot update to %s",
+                bookingId, booking.resourceId, resource.id()));
+        }
+
+        booking.resourceType = resource.type();
+        booking.resourceLabel = resource.label();
+        booking.resourceData = resource.data();
+        booking.persist();
+
+        LOG.infof("Updated booking %s resource data for resource %s", booking.id, booking.resourceId);
 
         return booking;
     }

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
@@ -263,6 +263,76 @@ class BookingResourceTest {
     }
 
     @Test
+    @Order(7)
+    void testUpdateBookingResourceData() {
+        // Update the booking's resource payload in place (slot unchanged).
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "resource": {
+                        "id": "%s",
+                        "type": "SERVICE",
+                        "label": "Acme Corp - assigned",
+                        "data": {
+                            "cliente": "Acme Corp",
+                            "assignedCarrier": "carrier-uuid",
+                            "assignedDriver": "driver-uuid",
+                            "assignedTruck": "truck-uuid"
+                        }
+                    }
+                }
+                """, RESOURCE_ID))
+            .when()
+            .put(bookingsUrl + "/" + bookingId)
+            .then()
+            .statusCode(200)
+            .body("id", equalTo(bookingId))
+            .body("resource.id", equalTo(RESOURCE_ID))
+            .body("resource.label", equalTo("Acme Corp - assigned"))
+            .body("resource.data.assignedCarrier", equalTo("carrier-uuid"));
+
+        // GET reflects the new data.
+        given()
+            .when()
+            .get(bookingsUrl + "/" + bookingId)
+            .then()
+            .statusCode(200)
+            .body("resource.data.assignedTruck", equalTo("truck-uuid"));
+
+        // A PUT that tries to repoint the booking to a different resource is rejected.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "resource": {
+                        "id": "SRV-OTHER",
+                        "type": "SERVICE"
+                    }
+                }
+                """)
+            .when()
+            .put(bookingsUrl + "/" + bookingId)
+            .then()
+            .statusCode(400);
+    }
+
+    @Test
+    void testUpdateBookingNotFound() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "resource": { "id": "SRV-001" }
+                }
+                """)
+            .when()
+            .put(bookingsUrl + "/00000000-0000-0000-0000-000000000000")
+            .then()
+            .statusCode(404);
+    }
+
+    @Test
     @Order(8)
     void testCancelBooking() {
         given()


### PR DESCRIPTION
## Summary
- Adds `PUT /api/v1/miot-calendar/bookings/{id}` to update an existing booking's resource payload (`type` / `label` / `data`) **in place**. The slot is not changed — move a booking by cancelling and recreating it.
- Closes the gap where the only way to "update" a booking was to POST a new one for the same `(calendar, resource, slot)`, which hits `uk_cld_bookings_slot_resource` and returns `409`, silently dropping the new `resource.data`.
- `BookingService.updateBookingResource`: `404` if the booking is missing, `400` if the request would repoint the booking to a different resource id; otherwise updates `resourceType`/`resourceLabel`/`resourceData` (`@PreUpdate` bumps `updated_at`). No slot/occupancy changes.
- `BookingUpdateRequest { resource }` model; `BookingResourceTest` coverage; bruno `Update Booking` request; version `0.4.1 → 0.4.2`.
- No DB migration — `cld_bookings.resource_data` (jsonb) and `updated_at` already exist.

## Test plan
- [x] `./mvnw test -Dtest=BookingResourceTest` → 13/13 pass (includes `testUpdateBookingResourceData`, `testUpdateBookingNotFound`)
- [x] `./mvnw -o test-compile` clean
- [x] Manual: PUT a booking via bruno → 200, GET reflects new data; PUT unknown id → 404; PUT with mismatched `resource.id` → 400

## Related
Frontend consumer: microboxlabs/modulariot#450 · ecm-coordinator#245

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.4.2

* **New Features**
  * Added ability to update booking resource data (driver information, license plate, and assigned carrier) without modifying the booking slot or dates.

* **Chores**
  * Version bumped to 0.4.2.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/miot-calendar/pull/25)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->