### PR TITLE
feat: per-time-window manual slot duration (AUTO/MANUAL mode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ jacoco.exec
 
 # Native image build
 native-image.properties
+
+# Cursor IDE plans (local-only scratchpads; git log is the durable record)
+.cursor/plans/

--- a/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
@@ -1,5 +1,6 @@
 package com.microboxlabs.miot.calendar.entity;
 
+import com.microboxlabs.miot.calendar.model.SlotGenerationMode;
 import com.microboxlabs.miot.calendar.model.TimeWindowKind;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.persistence.*;
@@ -61,6 +62,10 @@ public class TimeWindow extends PanacheEntityBase {
     @Enumerated(EnumType.STRING)
     @Column(name = "kind", nullable = false, length = 16)
     public TimeWindowKind kind = TimeWindowKind.WINDOW;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "slot_generation_mode", nullable = false, length = 8)
+    public SlotGenerationMode slotGenerationMode = SlotGenerationMode.MANUAL;
 
     @Column(name = "created_at", nullable = false)
     public ZonedDateTime createdAt;
@@ -130,6 +135,56 @@ public class TimeWindow extends PanacheEntityBase {
             return 0;
         }
         return Math.min(parallelism, remaining);
+    }
+
+    /**
+     * Effective slot step in minutes used when generating slots: the persisted
+     * {@code slotDurationMinutes}. AUTO windows have this kept in sync with
+     * {@link #computeSlotDurationMinutes()} on save; MANUAL windows use the admin's value.
+     */
+    public int effectiveSlotDurationMinutes() {
+        if (kind == TimeWindowKind.BLOCK) {
+            return BLOCK_SLOT_DURATION_MINUTES;
+        }
+        return (slotDurationMinutes != null && slotDurationMinutes > 0)
+                ? slotDurationMinutes
+                : Math.max(computeSlotDurationMinutes(), 1);
+    }
+
+    /**
+     * Total number of slots generated across the window.
+     * <ul>
+     *   <li>BLOCK — 0 (the generator fills the whole range with CLOSED cells independently).</li>
+     *   <li>WINDOW + AUTO — {@link #computeNumberOfSlots()} (every slot bookable).</li>
+     *   <li>WINDOW + MANUAL — {@code floor(windowMinutes / slotDurationMinutes)}; the leftover tail
+     *       (if the duration doesn't divide the window evenly) is unused.</li>
+     * </ul>
+     */
+    public int totalSlots() {
+        if (kind == TimeWindowKind.BLOCK) {
+            return 0;
+        }
+        if (slotGenerationMode == SlotGenerationMode.MANUAL) {
+            int windowMinutes = (endHour - startHour) * 60;
+            return Math.max(windowMinutes / effectiveSlotDurationMinutes(), 0);
+        }
+        return computeNumberOfSlots();
+    }
+
+    /**
+     * Number of leading slots that are bookable (status OPEN). The rest, up to {@link #totalSlots()},
+     * are generated as {@link com.microboxlabs.miot.calendar.model.SlotStatus#OVERFLOW}.
+     * For AUTO this equals {@link #totalSlots()}; for MANUAL it is the capacity model's slot count
+     * ({@code ceil(capacity / parallelism)}) capped at the number of slots that fit.
+     */
+    public int bookableSlots() {
+        if (kind == TimeWindowKind.BLOCK) {
+            return 0;
+        }
+        if (slotGenerationMode == SlotGenerationMode.MANUAL) {
+            return Math.min(computeNumberOfSlots(), totalSlots());
+        }
+        return computeNumberOfSlots();
     }
 
     // Finder methods

--- a/src/main/java/com/microboxlabs/miot/calendar/model/SlotGenerationMode.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/SlotGenerationMode.java
@@ -1,0 +1,25 @@
+package com.microboxlabs.miot.calendar.model;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * How a time window's slot duration is determined.
+ */
+@Schema(description = "Slot generation mode for a time window", enumeration = {"AUTO", "MANUAL"})
+public enum SlotGenerationMode {
+    /**
+     * Slot duration is derived from the window length and the capacity model:
+     * {@code numberOfSlots = ceil(capacity / parallelism)},
+     * {@code slotDurationMinutes = windowMinutes / numberOfSlots}. Every generated slot is bookable.
+     */
+    AUTO,
+
+    /**
+     * Slot duration is set explicitly by the admin ({@code slotDurationMinutes}). The window is
+     * filled with {@code floor(windowMinutes / slotDurationMinutes)} slots; only the first
+     * {@code ceil(capacity / parallelism)} are bookable ({@code OPEN}) — the remainder are generated
+     * as {@link SlotStatus#OVERFLOW} so the planning grid can render them, but bookings against
+     * those slots are rejected.
+     */
+    MANUAL
+}

--- a/src/main/java/com/microboxlabs/miot/calendar/model/SlotStatus.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/SlotStatus.java
@@ -5,7 +5,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 /**
  * Slot status enum
  */
-@Schema(description = "Status of a booking slot", enumeration = {"OPEN", "FULL", "CLOSED"})
+@Schema(description = "Status of a booking slot", enumeration = {"OPEN", "FULL", "CLOSED", "OVERFLOW"})
 public enum SlotStatus {
     /**
      * Slot is open for bookings
@@ -20,5 +20,12 @@ public enum SlotStatus {
     /**
      * Slot is manually closed (not accepting bookings)
      */
-    CLOSED
+    CLOSED,
+
+    /**
+     * Slot was generated beyond the time window's bookable quota (MANUAL slot generation):
+     * it exists so the planning grid can render it, but it carries zero capacity and bookings
+     * against it are rejected.
+     */
+    OVERFLOW
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowRequest.java
@@ -37,13 +37,27 @@ public record TimeWindowRequest(
     String color,
 
     @Schema(description = "Discriminator: WINDOW (bookable, default) or BLOCK (non-bookable)", defaultValue = "WINDOW")
-    TimeWindowKind kind
+    TimeWindowKind kind,
+
+    @Schema(description = "Slot generation mode: AUTO derives slot duration from capacity/parallelism; "
+            + "MANUAL uses slotDurationMinutes. Ignored for BLOCK windows.", defaultValue = "MANUAL")
+    SlotGenerationMode slotGenerationMode,
+
+    @Schema(description = "Slot length in minutes. Required only when slotGenerationMode = MANUAL on a "
+            + "WINDOW; if omitted there it is seeded from the capacity model. Ignored for AUTO and BLOCK. "
+            + "Must be between 5 and the window length in minutes.", minimum = "5", examples = {"10"})
+    Integer slotDurationMinutes
 ) {
+    /** Minimum admin-settable slot duration, in minutes. */
+    public static final int MIN_MANUAL_SLOT_DURATION_MINUTES = 5;
+
     /**
-     * Validate the time window request.
+     * Validate the time window request (create path).
      *
-     * BLOCK windows accept null/0 capacity since they generate non-bookable
-     * slots; WINDOW windows still require capacity >= 1.
+     * BLOCK windows accept null/0 capacity since they generate non-bookable slots; WINDOW windows
+     * still require capacity >= 1. A MANUAL WINDOW with an explicit slotDurationMinutes must keep it
+     * within [{@value #MIN_MANUAL_SLOT_DURATION_MINUTES}, window-length-minutes]; a null value is
+     * allowed (the service seeds it from the capacity model).
      */
     public void validate() {
         if (name == null || name.isBlank()) {
@@ -62,6 +76,7 @@ public record TimeWindowRequest(
             throw new IllegalArgumentException("Valid to date must be after valid from date");
         }
         validateCapacity();
+        validateManualSlotDuration();
     }
 
     private void validateCapacity() {
@@ -71,6 +86,24 @@ public record TimeWindowRequest(
         int min = kind == TimeWindowKind.BLOCK ? 0 : 1;
         if (capacity < min) {
             throw new IllegalArgumentException("Capacity must be at least " + min);
+        }
+    }
+
+    /** True when this request describes a MANUAL bookable window (BLOCK and AUTO ignore the duration). */
+    public boolean isManualWindow() {
+        return kind != TimeWindowKind.BLOCK
+            && (slotGenerationMode == null || slotGenerationMode == SlotGenerationMode.MANUAL);
+    }
+
+    private void validateManualSlotDuration() {
+        if (!isManualWindow() || slotDurationMinutes == null) {
+            return;
+        }
+        int windowMinutes = (endHour - startHour) * 60;
+        if (slotDurationMinutes < MIN_MANUAL_SLOT_DURATION_MINUTES || slotDurationMinutes > windowMinutes) {
+            throw new IllegalArgumentException(
+                "Slot duration must be between " + MIN_MANUAL_SLOT_DURATION_MINUTES
+                    + " and " + windowMinutes + " minutes (the window length)");
         }
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowResponse.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowResponse.java
@@ -27,7 +27,7 @@ public record TimeWindowResponse(
     @Schema(required = true, description = "End hour of the time window (exclusive)", minimum = "0", maximum = "23", examples = {"12"})
     Integer endHour,
 
-    @Schema(required = true, description = "Duration of each slot in minutes (derived from capacity model)", minimum = "1", examples = {"60"})
+    @Schema(required = true, description = "Duration of each slot in minutes (admin-set when slotGenerationMode = MANUAL, derived from the capacity model otherwise)", minimum = "1", examples = {"10"})
     Integer slotDurationMinutes,
 
     @Schema(required = true, description = "Total number of services this window can handle across all slots", minimum = "1", examples = {"20"})
@@ -50,6 +50,15 @@ public record TimeWindowResponse(
 
     @Schema(required = true, description = "Discriminator: WINDOW (bookable) or BLOCK (non-bookable)")
     TimeWindowKind kind,
+
+    @Schema(required = true, description = "Slot generation mode: AUTO (slot duration derived from capacity/parallelism) or MANUAL (admin-set slot duration)")
+    SlotGenerationMode slotGenerationMode,
+
+    @Schema(required = true, description = "Total number of slots generated across the window (floor(windowMinutes / slotDurationMinutes) in MANUAL mode; for BLOCK windows this is 0)", minimum = "0", examples = {"24"})
+    Integer totalSlots,
+
+    @Schema(required = true, description = "How many of the generated slots are bookable (OPEN); the remainder, up to totalSlots, are OVERFLOW", minimum = "0", examples = {"20"})
+    Integer bookableSlots,
 
     @Schema(required = true, description = "Timestamp when the time window was created", format = "date-time")
     ZonedDateTime createdAt,
@@ -75,6 +84,9 @@ public record TimeWindowResponse(
             timeWindow.active,
             timeWindow.color,
             timeWindow.kind,
+            timeWindow.slotGenerationMode,
+            timeWindow.totalSlots(),
+            timeWindow.bookableSlots(),
             timeWindow.createdAt,
             timeWindow.updatedAt
         );

--- a/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
@@ -6,6 +6,7 @@ import com.microboxlabs.miot.calendar.entity.Slot;
 import com.microboxlabs.miot.calendar.entity.SlotManager;
 import com.microboxlabs.miot.calendar.entity.TimeWindow;
 import com.microboxlabs.miot.calendar.model.CalendarRequest;
+import com.microboxlabs.miot.calendar.model.SlotGenerationMode;
 import com.microboxlabs.miot.calendar.model.SlotManagerTriggerEvent;
 import com.microboxlabs.miot.calendar.model.TimeWindowKind;
 import com.microboxlabs.miot.calendar.model.TimeWindowRequest;
@@ -177,7 +178,12 @@ public class CalendarService {
     private void reprocessSlotsForParallelismChange(UUID calendarId) {
         List<TimeWindow> timeWindows = TimeWindow.findActiveByCalendarId(calendarId);
         for (TimeWindow tw : timeWindows) {
-            tw.slotDurationMinutes = tw.computeSlotDurationMinutes();
+            // Only AUTO windows re-derive their slot length from the new parallelism. MANUAL windows
+            // keep the admin-set duration; their bookable/overflow split still shifts on regen because
+            // bookableSlots() = ceil(capacity / parallelism) changed.
+            if (tw.slotGenerationMode == SlotGenerationMode.AUTO) {
+                tw.slotDurationMinutes = tw.computeSlotDurationMinutes();
+            }
         }
         triggerSlotManagerReprocess(calendarId);
     }
@@ -282,9 +288,13 @@ public class CalendarService {
         timeWindow.startHour = request.startHour();
         timeWindow.endHour = request.endHour();
         timeWindow.kind = request.kind() != null ? request.kind() : TimeWindowKind.WINDOW;
+        timeWindow.slotGenerationMode = resolveSlotGenerationMode(request.slotGenerationMode());
         timeWindow.capacity = resolveCapacity(request.capacity(), timeWindow.kind);
         timeWindow.daysOfWeek = request.daysOfWeek() != null ? request.daysOfWeek() : "1,2,3,4,5";
-        timeWindow.slotDurationMinutes = timeWindow.computeSlotDurationMinutes();
+        // Clear the entity default so applySlotDuration resolves it from the request or the derived
+        // value rather than treating the placeholder 30 as an admin-chosen duration.
+        timeWindow.slotDurationMinutes = null;
+        applySlotDuration(timeWindow, request.slotDurationMinutes());
         timeWindow.validFrom = request.validFrom();
         timeWindow.validTo = request.validTo();
         timeWindow.active = request.active() != null ? request.active() : true;
@@ -307,8 +317,8 @@ public class CalendarService {
         }
 
         boolean needsRecompute = applyTimeWindowFields(timeWindow, request);
-        if (needsRecompute) {
-            timeWindow.slotDurationMinutes = timeWindow.computeSlotDurationMinutes();
+        if (needsRecompute || request.slotDurationMinutes() != null) {
+            applySlotDuration(timeWindow, request.slotDurationMinutes());
         }
 
         LOG.infof("Updated time window: %s", timeWindow.name);
@@ -326,6 +336,44 @@ public class CalendarService {
         return kind == TimeWindowKind.BLOCK ? 0 : 1;
     }
 
+    /** Default slot generation mode for new windows: MANUAL. */
+    private static SlotGenerationMode resolveSlotGenerationMode(SlotGenerationMode requested) {
+        return requested != null ? requested : SlotGenerationMode.MANUAL;
+    }
+
+    /**
+     * Resolve and persist {@code slotDurationMinutes} after a window's other fields are set.
+     * <ul>
+     *   <li>BLOCK or AUTO — derived ({@link TimeWindow#computeSlotDurationMinutes()}); any requested value is ignored.</li>
+     *   <li>MANUAL WINDOW — uses {@code requestedDuration} (validated to
+     *       [{@value TimeWindowRequest#MIN_MANUAL_SLOT_DURATION_MINUTES}, windowMinutes]); if absent, keeps the current
+     *       value when it is still usable ({@code 0 < d <= windowMinutes}), otherwise seeds it from the derived value
+     *       (so a freshly-created window or one whose window shrank below the old duration falls back to AUTO-equivalent).</li>
+     * </ul>
+     * Throws {@link IllegalArgumentException} (mapped to HTTP 400 by the resource layer) on an out-of-range requested value.
+     */
+    private static void applySlotDuration(TimeWindow tw, Integer requestedDuration) {
+        if (tw.kind == TimeWindowKind.BLOCK || tw.slotGenerationMode == SlotGenerationMode.AUTO) {
+            tw.slotDurationMinutes = tw.computeSlotDurationMinutes();
+            return;
+        }
+        int windowMinutes = (tw.endHour - tw.startHour) * 60;
+        if (requestedDuration != null) {
+            int min = TimeWindowRequest.MIN_MANUAL_SLOT_DURATION_MINUTES;
+            if (requestedDuration < min || requestedDuration > windowMinutes) {
+                throw new IllegalArgumentException(
+                    "Slot duration must be between " + min + " and " + windowMinutes + " minutes (the window length)");
+            }
+            tw.slotDurationMinutes = requestedDuration;
+            return;
+        }
+        Integer current = tw.slotDurationMinutes;
+        if (current == null || current <= 0 || current > windowMinutes) {
+            tw.slotDurationMinutes = tw.computeSlotDurationMinutes();
+        }
+        // else: keep the existing admin-set duration unchanged (capacity/parallelism edits don't move it).
+    }
+
     private boolean applyTimeWindowFields(TimeWindow tw, TimeWindowRequest request) {
         boolean needsRecompute = false;
         if (request.name() != null)      tw.name = request.name();
@@ -338,6 +386,7 @@ public class CalendarService {
         if (request.active() != null)     tw.active = request.active();
         if (request.color() != null)      tw.color = request.color();
         if (request.kind() != null)      { tw.kind = request.kind();           needsRecompute = true; }
+        if (request.slotGenerationMode() != null) { tw.slotGenerationMode = request.slotGenerationMode(); needsRecompute = true; }
         return needsRecompute;
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/service/SlotGeneratorService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/SlotGeneratorService.java
@@ -87,22 +87,26 @@ public class SlotGeneratorService {
 
     private void generateSlotsForWindow(Calendar calendar, TimeWindow timeWindow,
                                         LocalDate date, int[] counts) {
+        boolean isBlock = timeWindow.kind == TimeWindowKind.BLOCK;
         int hour = timeWindow.startHour;
         int minutes = 0;
         int slotIndex = 0;
-        int maxSlots = timeWindow.kind == TimeWindowKind.BLOCK
-                ? Integer.MAX_VALUE
-                : timeWindow.computeNumberOfSlots();
+        int step = timeWindow.effectiveSlotDurationMinutes();
+        // BLOCK fills the whole range with CLOSED cells; WINDOW emits totalSlots() slots, of which
+        // the first bookableSlots() are OPEN and the rest are OVERFLOW (MANUAL mode only — for AUTO
+        // bookableSlots() == totalSlots() so no OVERFLOW slots are produced).
+        int maxSlots = isBlock ? Integer.MAX_VALUE : timeWindow.totalSlots();
+        int bookable = isBlock ? 0 : timeWindow.bookableSlots();
 
         while (hour < timeWindow.endHour && slotIndex < maxSlots) {
             Slot existing = Slot.findByCalendarAndDateTime(calendar.id, date, hour, minutes);
             if (existing == null) {
-                createSlot(calendar, timeWindow, date, hour, minutes, slotIndex);
+                createSlot(calendar, timeWindow, date, hour, minutes, slotIndex, bookable);
                 counts[0]++;
-            } else if (timeWindow.kind == TimeWindowKind.BLOCK
-                    && existing.status == SlotStatus.OPEN
+            } else if (isBlock
+                    && (existing.status == SlotStatus.OPEN || existing.status == SlotStatus.OVERFLOW)
                     && existing.currentOccupancy == 0) {
-                // BLOCK overrides an unbooked OPEN slot left by a colliding window.
+                // BLOCK overrides an unbooked OPEN/OVERFLOW slot left by a colliding window.
                 existing.status = SlotStatus.CLOSED;
                 existing.timeWindow = timeWindow;
                 existing.capacity = 0;
@@ -111,7 +115,7 @@ public class SlotGeneratorService {
                 counts[1]++;
             }
 
-            minutes += timeWindow.slotDurationMinutes;
+            minutes += step;
             if (minutes >= 60) {
                 hour += minutes / 60;
                 minutes = minutes % 60;
@@ -121,21 +125,24 @@ public class SlotGeneratorService {
     }
 
     private void createSlot(Calendar calendar, TimeWindow timeWindow,
-                            LocalDate date, int hour, int minutes, int slotIndex) {
+                            LocalDate date, int hour, int minutes, int slotIndex, int bookableSlots) {
         Slot slot = new Slot();
         slot.calendar = calendar;
         slot.timeWindow = timeWindow;
         slot.slotDate = date;
         slot.slotHour = hour;
         slot.slotMinutes = minutes;
+        slot.currentOccupancy = 0;
         if (timeWindow.kind == TimeWindowKind.BLOCK) {
             slot.capacity = 0;
-            slot.currentOccupancy = 0;
             slot.status = SlotStatus.CLOSED;
-        } else {
+        } else if (slotIndex < bookableSlots) {
             slot.capacity = timeWindow.computeSlotCapacity(slotIndex);
-            slot.currentOccupancy = 0;
             slot.status = SlotStatus.OPEN;
+        } else {
+            // Generated beyond the window's bookable quota (MANUAL mode): rendered but not bookable.
+            slot.capacity = 0;
+            slot.status = SlotStatus.OVERFLOW;
         }
         slot.persist();
     }

--- a/src/main/java/com/microboxlabs/miot/calendar/validation/BookingValidationService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/validation/BookingValidationService.java
@@ -48,6 +48,12 @@ public class BookingValidationService {
                 "SLOT_CLOSED"
             );
         }
+        if (slot.status == SlotStatus.OVERFLOW) {
+            throw new BookingValidationException(
+                "Slot was generated beyond the time window's bookable capacity",
+                "SLOT_OVERFLOW"
+            );
+        }
         if (slot.status == SlotStatus.FULL) {
             throw new BookingValidationException(
                 "Slot is at full capacity",

--- a/src/main/resources/db/migration/V12__add_slot_generation_mode.sql
+++ b/src/main/resources/db/migration/V12__add_slot_generation_mode.sql
@@ -1,0 +1,30 @@
+-- V12: Per-time-window manual slot duration
+--
+-- Adds `slot_generation_mode` to time windows:
+--   AUTO   = slot_duration_minutes is derived from capacity/parallelism (historical behaviour).
+--   MANUAL = slot_duration_minutes is admin-set; slots beyond the window's bookable quota are
+--            still generated (so the planning grid can render them) but marked OVERFLOW.
+-- New default is MANUAL. Existing rows keep their already-persisted slot_duration_minutes, which
+-- makes this migration behaviour-preserving for parallelism = 1 (and a no-op visual change on
+-- deploy); switching a window to AUTO recomputes the duration on the next save.
+--
+-- Also relaxes the cld_slots status CHECK to include 'OVERFLOW'.
+
+ALTER TABLE cld_time_windows
+    ADD COLUMN slot_generation_mode VARCHAR(8) NOT NULL DEFAULT 'MANUAL'
+        CHECK (slot_generation_mode IN ('AUTO', 'MANUAL'));
+
+COMMENT ON COLUMN cld_time_windows.slot_generation_mode IS
+    'AUTO = slot_duration_minutes derived from capacity/parallelism; MANUAL = admin-set slot length';
+COMMENT ON COLUMN cld_time_windows.slot_duration_minutes IS
+    'Slot length in minutes - admin-authoritative when slot_generation_mode = MANUAL, derived otherwise';
+
+ALTER TABLE cld_slots
+    DROP CONSTRAINT IF EXISTS cld_slots_status_check;
+
+ALTER TABLE cld_slots
+    ADD CONSTRAINT cld_slots_status_check
+        CHECK (status IN ('OPEN', 'FULL', 'CLOSED', 'OVERFLOW'));
+
+COMMENT ON COLUMN cld_slots.status IS
+    'OPEN = bookable; FULL = at capacity; CLOSED = blocked (BLOCK window); OVERFLOW = generated beyond window quota, not bookable';

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/ManualSlotDurationResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/ManualSlotDurationResourceTest.java
@@ -1,0 +1,172 @@
+package com.microboxlabs.miot.calendar.resource;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.time.LocalDate;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * REST-level coverage for the MANUAL slot-generation mode wired through CalendarResource:
+ * explicit slot duration vs. seeded-from-capacity, the [5, windowMinutes] validation bounds, the
+ * derived totalSlots/bookableSlots on the response, AUTO↔MANUAL round-tripping, and the fact that a
+ * parallelism change leaves a MANUAL window's admin-set duration alone (only AUTO windows re-derive).
+ */
+@QuarkusTest
+class ManualSlotDurationResourceTest {
+
+    private static final String CALENDARS_PATH = "/api/v1/miot-calendar/calendars";
+    private static final LocalDate VALID_FROM = LocalDate.now();
+
+    @TestHTTPResource
+    URL url;
+
+    @BeforeEach
+    void setupRestAssured() {
+        RestAssured.baseURI = url.toString();
+        RestAssured.port = url.getPort();
+    }
+
+    private String createCalendar(String code, int parallelism) {
+        return given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                { "code": "%s", "name": "%s", "parallelism": %d }
+                """, code, code, parallelism))
+            .when().post(CALENDARS_PATH)
+            .then().statusCode(201)
+            .extract().path("id");
+    }
+
+    private static String timeWindowBody(String generationMode, Integer slotDurationMinutes,
+                                         int startHour, int endHour, int capacity) {
+        String duration = slotDurationMinutes == null ? "" : "\"slotDurationMinutes\": " + slotDurationMinutes + ",";
+        return String.format("""
+            {
+                "name": "Loading Window",
+                "slotGenerationMode": "%s",
+                %s
+                "startHour": %d,
+                "endHour": %d,
+                "capacity": %d,
+                "daysOfWeek": "1,2,3,4,5",
+                "validFrom": "%s"
+            }
+            """, generationMode, duration, startHour, endHour, capacity, VALID_FROM);
+    }
+
+    private io.restassured.response.Response postTimeWindow(String calendarId, String body) {
+        return given().contentType(ContentType.JSON).body(body)
+            .when().post(CALENDARS_PATH + "/" + calendarId + "/time-windows")
+            .thenReturn();
+    }
+
+    @Test
+    void createsManualWindowWithExplicitDurationAndDerivedSlotCounts() {
+        String calendarId = createCalendar("msd-explicit", 1);
+        // 4h window, 10-min slots → 24 slots fit; capacity 20, parallelism 1 → 20 OPEN, 4 OVERFLOW.
+        given().contentType(ContentType.JSON).body(timeWindowBody("MANUAL", 10, 8, 12, 20))
+            .when().post(CALENDARS_PATH + "/" + calendarId + "/time-windows")
+            .then().statusCode(201)
+            .body("slotGenerationMode", equalTo("MANUAL"))
+            .body("slotDurationMinutes", equalTo(10))
+            .body("totalSlots", equalTo(24))
+            .body("bookableSlots", equalTo(20));
+    }
+
+    @Test
+    void seedsManualSlotDurationFromCapacityModelWhenOmitted() {
+        String calendarId = createCalendar("msd-seeded", 1);
+        // No slotDurationMinutes → seeded = 240min / ceil(4/1) = 60.
+        given().contentType(ContentType.JSON).body(timeWindowBody("MANUAL", null, 8, 12, 4))
+            .when().post(CALENDARS_PATH + "/" + calendarId + "/time-windows")
+            .then().statusCode(201)
+            .body("slotGenerationMode", equalTo("MANUAL"))
+            .body("slotDurationMinutes", equalTo(60))
+            .body("totalSlots", equalTo(4))
+            .body("bookableSlots", equalTo(4));
+    }
+
+    @Test
+    void rejectsManualSlotDurationBelowMinimum() {
+        String calendarId = createCalendar("msd-too-short", 1);
+        postTimeWindow(calendarId, timeWindowBody("MANUAL", 3, 8, 12, 4))
+            .then().statusCode(400);
+    }
+
+    @Test
+    void rejectsManualSlotDurationLongerThanWindow() {
+        String calendarId = createCalendar("msd-too-long", 1);
+        // 8-12 = 240 min; 300 > 240 → rejected.
+        postTimeWindow(calendarId, timeWindowBody("MANUAL", 300, 8, 12, 4))
+            .then().statusCode(400);
+    }
+
+    @Test
+    void roundTripsBetweenAutoAndManual() {
+        String calendarId = createCalendar("msd-roundtrip", 1);
+        String twId = given().contentType(ContentType.JSON).body(timeWindowBody("AUTO", null, 8, 12, 4))
+            .when().post(CALENDARS_PATH + "/" + calendarId + "/time-windows")
+            .then().statusCode(201)
+            .body("slotGenerationMode", equalTo("AUTO"))
+            .body("slotDurationMinutes", equalTo(60))   // 240 / ceil(4/1)
+            .extract().path("id");
+
+        String twPath = CALENDARS_PATH + "/" + calendarId + "/time-windows/" + twId;
+
+        // AUTO → MANUAL with no duration: seeded from the (current) derived value.
+        given().contentType(ContentType.JSON).body("{ \"slotGenerationMode\": \"MANUAL\" }")
+            .when().put(twPath)
+            .then().statusCode(200)
+            .body("slotGenerationMode", equalTo("MANUAL"))
+            .body("slotDurationMinutes", equalTo(60));
+
+        // MANUAL: set an explicit duration.
+        given().contentType(ContentType.JSON).body("{ \"slotGenerationMode\": \"MANUAL\", \"slotDurationMinutes\": 20 }")
+            .when().put(twPath)
+            .then().statusCode(200)
+            .body("slotDurationMinutes", equalTo(20))
+            .body("totalSlots", equalTo(12))     // 240 / 20
+            .body("bookableSlots", equalTo(4));  // ceil(4/1), capped at 12
+
+        // MANUAL → AUTO: duration re-derived, OVERFLOW gone (bookableSlots == totalSlots).
+        given().contentType(ContentType.JSON).body("{ \"slotGenerationMode\": \"AUTO\" }")
+            .when().put(twPath)
+            .then().statusCode(200)
+            .body("slotGenerationMode", equalTo("AUTO"))
+            .body("slotDurationMinutes", equalTo(60))
+            .body("totalSlots", equalTo(4))
+            .body("bookableSlots", equalTo(4));
+    }
+
+    @Test
+    void parallelismChangeLeavesManualWindowDurationUntouched() {
+        String calendarId = createCalendar("msd-par-keep", 1);
+        // MANUAL 30-min slots over a 4h window: 8 slots fit; capacity 4, parallelism 1 → 4 OPEN + 4 OVERFLOW.
+        given().contentType(ContentType.JSON).body(timeWindowBody("MANUAL", 30, 8, 12, 4))
+            .when().post(CALENDARS_PATH + "/" + calendarId + "/time-windows")
+            .then().statusCode(201)
+            .body("slotDurationMinutes", equalTo(30))
+            .body("totalSlots", equalTo(8))
+            .body("bookableSlots", equalTo(4));
+
+        // Bump parallelism — a MANUAL window keeps its duration; only bookableSlots re-lays.
+        given().contentType(ContentType.JSON).body("{ \"parallelism\": 2 }")
+            .when().put(CALENDARS_PATH + "/" + calendarId)
+            .then().statusCode(200).body("parallelism", equalTo(2));
+
+        given().when().get(CALENDARS_PATH + "/" + calendarId + "/time-windows")
+            .then().statusCode(200)
+            .body("[0].slotGenerationMode", equalTo("MANUAL"))
+            .body("[0].slotDurationMinutes", equalTo(30))  // unchanged
+            .body("[0].totalSlots", equalTo(8))            // unchanged
+            .body("[0].bookableSlots", equalTo(2));        // ceil(4/2)
+    }
+}

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/ParallelismCapacityTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/ParallelismCapacityTest.java
@@ -82,6 +82,7 @@ class ParallelismCapacityTest {
             .body(String.format("""
                 {
                     "name": "Test Window",
+                    "slotGenerationMode": "AUTO",
                     "startHour": %d,
                     "endHour": %d,
                     "capacity": %d,

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/ParallelismEdgeCaseTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/ParallelismEdgeCaseTest.java
@@ -93,6 +93,7 @@ class ParallelismEdgeCaseTest {
             .body(String.format("""
                 {
                     "name": "Test Window",
+                    "slotGenerationMode": "AUTO",
                     "startHour": %d,
                     "endHour": %d,
                     "capacity": %d,
@@ -113,6 +114,7 @@ class ParallelismEdgeCaseTest {
             .body(String.format("""
                 {
                     "name": "Test Window",
+                    "slotGenerationMode": "AUTO",
                     "startHour": %d,
                     "endHour": %d,
                     "capacity": %d,

--- a/src/test/java/com/microboxlabs/miot/calendar/service/SlotGeneratorServiceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/service/SlotGeneratorServiceTest.java
@@ -6,6 +6,7 @@ import com.microboxlabs.miot.calendar.entity.TimeWindow;
 import com.microboxlabs.miot.calendar.model.SlotGenerationMode;
 import com.microboxlabs.miot.calendar.model.SlotStatus;
 import com.microboxlabs.miot.calendar.model.TimeWindowKind;
+import io.quarkus.hibernate.orm.panache.Panache;
 import io.quarkus.test.TestTransaction;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -164,5 +165,54 @@ class SlotGeneratorServiceTest {
         slots.stream()
                 .filter(s -> s.slotHour >= 10)
                 .forEach(s -> assertEquals(SlotStatus.CLOSED, s.status, "slot at " + s.slotHour + ":" + s.slotMinutes));
+    }
+
+    @Test
+    @TestTransaction
+    void bookedSlotSurvivesReprocessAfterCapacityDrop() {
+        // 4h window, 30-min slots → 8 slots; capacity 8, parallelism 1 → all 8 OPEN.
+        Calendar cal = persistCalendar("gsvc-reproc", 1);
+        TimeWindow tw = persistWindow(cal, TimeWindowKind.WINDOW, SlotGenerationMode.MANUAL, 8, 12, 30, 8);
+        slotGeneratorService.generateSlots(cal.id, A_MONDAY, A_MONDAY);
+
+        // Simulate a booking on the 08:00 slot, then drop the window capacity (bookable → ceil(2/1) = 2).
+        Slot first = Slot.findByCalendarAndDateTime(cal.id, A_MONDAY, 8, 0);
+        first.currentOccupancy = 1;
+        tw.capacity = 2;
+        Panache.getEntityManager().flush();
+        Panache.getEntityManager().clear();
+
+        slotGeneratorService.generateSlots(cal.id, A_MONDAY, A_MONDAY, true); // reprocess: drop unbooked, regenerate
+
+        List<Slot> slots = Slot.findByCalendarAndDateRange(cal.id, A_MONDAY, A_MONDAY);
+        assertEquals(8, slots.size(), "8 slots still fit the window regardless of the lowered bookable count");
+        Slot surviving = slots.stream()
+                .filter(s -> s.slotHour == 8 && s.slotMinutes == 0)
+                .findFirst().orElseThrow();
+        assertEquals(1, surviving.currentOccupancy, "the booked slot is preserved across the reprocess");
+        assertEquals(6, countByStatus(slots, SlotStatus.OVERFLOW), "slots beyond the lowered bookable quota become OVERFLOW");
+    }
+
+    @Test
+    @TestTransaction
+    void manualToAutoReprocessDropsOverflowSlots() {
+        // MANUAL 4h/10-min/cap20/p1 → 24 slots, 4 of them OVERFLOW.
+        Calendar cal = persistCalendar("gsvc-m2a", 1);
+        TimeWindow tw = persistWindow(cal, TimeWindowKind.WINDOW, SlotGenerationMode.MANUAL, 8, 12, 10, 20);
+        slotGeneratorService.generateSlots(cal.id, A_MONDAY, A_MONDAY);
+        assertEquals(4, countByStatus(Slot.findByCalendarAndDateRange(cal.id, A_MONDAY, A_MONDAY), SlotStatus.OVERFLOW));
+
+        // Switch to AUTO (mimic CalendarService: re-derive the duration), then reprocess.
+        tw.slotGenerationMode = SlotGenerationMode.AUTO;
+        tw.slotDurationMinutes = tw.computeSlotDurationMinutes(); // 240 / ceil(20/1) = 12
+        Panache.getEntityManager().flush();
+        Panache.getEntityManager().clear();
+
+        slotGeneratorService.generateSlots(cal.id, A_MONDAY, A_MONDAY, true);
+
+        List<Slot> slots = Slot.findByCalendarAndDateRange(cal.id, A_MONDAY, A_MONDAY);
+        assertEquals(0, countByStatus(slots, SlotStatus.OVERFLOW), "AUTO never produces OVERFLOW slots");
+        assertEquals(20, slots.size());
+        assertTrue(slots.stream().allMatch(s -> s.status == SlotStatus.OPEN));
     }
 }

--- a/src/test/java/com/microboxlabs/miot/calendar/service/SlotGeneratorServiceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/service/SlotGeneratorServiceTest.java
@@ -1,0 +1,168 @@
+package com.microboxlabs.miot.calendar.service;
+
+import com.microboxlabs.miot.calendar.entity.Calendar;
+import com.microboxlabs.miot.calendar.entity.Slot;
+import com.microboxlabs.miot.calendar.entity.TimeWindow;
+import com.microboxlabs.miot.calendar.model.SlotGenerationMode;
+import com.microboxlabs.miot.calendar.model.SlotStatus;
+import com.microboxlabs.miot.calendar.model.TimeWindowKind;
+import io.quarkus.test.TestTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Generator-level tests for MANUAL slot generation: slots beyond the window's bookable quota are
+ * emitted as {@link SlotStatus#OVERFLOW} (rendered, capacity 0, not bookable), AUTO behaviour is
+ * unchanged, and a colliding BLOCK window overrides an unbooked OVERFLOW cell to CLOSED.
+ *
+ * <p>These exercise {@link SlotGeneratorService} directly (the REST layer can't configure a MANUAL
+ * window until the time-window DTOs are wired). Each test runs inside a {@link TestTransaction} that
+ * rolls back, so persisted fixtures never leak between tests.
+ */
+@QuarkusTest
+class SlotGeneratorServiceTest {
+
+    /** A future Monday — always >= validFrom (today) and matches daysOfWeek "1". */
+    private static final LocalDate A_MONDAY =
+            LocalDate.now().with(TemporalAdjusters.next(DayOfWeek.MONDAY));
+
+    @Inject
+    SlotGeneratorService slotGeneratorService;
+
+    private Calendar persistCalendar(String code, int parallelism) {
+        Calendar c = new Calendar();
+        c.code = code;
+        c.name = code;
+        c.parallelism = parallelism;
+        c.persist();
+        return c;
+    }
+
+    private TimeWindow persistWindow(Calendar calendar, TimeWindowKind kind, SlotGenerationMode mode,
+                                     int startHour, int endHour, int slotDurationMinutes, int capacity) {
+        TimeWindow tw = new TimeWindow();
+        tw.calendar = calendar;
+        tw.name = kind + "-" + mode;
+        tw.kind = kind;
+        tw.slotGenerationMode = mode;
+        tw.startHour = startHour;
+        tw.endHour = endHour;
+        tw.slotDurationMinutes = slotDurationMinutes;
+        tw.capacity = capacity;
+        tw.daysOfWeek = "1";
+        tw.validFrom = LocalDate.now();
+        tw.active = true;
+        tw.persist();
+        return tw;
+    }
+
+    private List<Slot> generateAndFetch(UUID calendarId) {
+        slotGeneratorService.generateSlots(calendarId, A_MONDAY, A_MONDAY);
+        return Slot.findByCalendarAndDateRange(calendarId, A_MONDAY, A_MONDAY);
+    }
+
+    private long countByStatus(List<Slot> slots, SlotStatus status) {
+        return slots.stream().filter(s -> s.status == status).count();
+    }
+
+    @Test
+    @TestTransaction
+    void manualWindowEmitsOpenSlotsThenOverflow() {
+        // 4h window, 10-min slots → 24 slots fit; capacity 20, parallelism 1 → 20 OPEN + 4 OVERFLOW.
+        Calendar cal = persistCalendar("gsvc-overflow", 1);
+        persistWindow(cal, TimeWindowKind.WINDOW, SlotGenerationMode.MANUAL, 8, 12, 10, 20);
+
+        List<Slot> slots = generateAndFetch(cal.id);
+
+        assertEquals(24, slots.size(), "floor(240min / 10min) slots");
+        assertEquals(20, countByStatus(slots, SlotStatus.OPEN));
+        assertEquals(4, countByStatus(slots, SlotStatus.OVERFLOW));
+        assertEquals(0, countByStatus(slots, SlotStatus.CLOSED));
+        // First 20 are OPEN with capacity 1; last 4 are OVERFLOW with capacity 0.
+        for (int i = 0; i < slots.size(); i++) {
+            Slot s = slots.get(i);
+            if (i < 20) {
+                assertEquals(SlotStatus.OPEN, s.status, "slot " + i);
+                assertEquals(1, s.capacity, "slot " + i + " capacity");
+            } else {
+                assertEquals(SlotStatus.OVERFLOW, s.status, "slot " + i);
+                assertEquals(0, s.capacity, "slot " + i + " capacity");
+            }
+        }
+        // First slot at 08:00, last at 08:00 + 23*10min = 11:50.
+        assertEquals(8, slots.get(0).slotHour);
+        assertEquals(0, slots.get(0).slotMinutes);
+        assertEquals(11, slots.get(23).slotHour);
+        assertEquals(50, slots.get(23).slotMinutes);
+    }
+
+    @Test
+    @TestTransaction
+    void manualWindowRespectsParallelismRemainderOnTheLastBookableSlot() {
+        // 4h window, 30-min slots → 8 slots fit; capacity 7, parallelism 2 → ceil(7/2)=4 bookable
+        // with capacities [2,2,2,1]; the remaining 4 slots are OVERFLOW.
+        Calendar cal = persistCalendar("gsvc-remainder", 2);
+        persistWindow(cal, TimeWindowKind.WINDOW, SlotGenerationMode.MANUAL, 8, 12, 30, 7);
+
+        List<Slot> slots = generateAndFetch(cal.id);
+
+        assertEquals(8, slots.size());
+        assertEquals(List.of(2, 2, 2, 1, 0, 0, 0, 0), slots.stream().map(s -> s.capacity).toList());
+        assertEquals(4, countByStatus(slots, SlotStatus.OPEN));
+        assertEquals(4, countByStatus(slots, SlotStatus.OVERFLOW));
+        for (int i = 0; i < 4; i++) assertEquals(SlotStatus.OPEN, slots.get(i).status, "slot " + i);
+        for (int i = 4; i < 8; i++) assertEquals(SlotStatus.OVERFLOW, slots.get(i).status, "slot " + i);
+    }
+
+    @Test
+    @TestTransaction
+    void autoWindowGeneratesOnlyBookableSlots() {
+        // AUTO: numberOfSlots = ceil(capacity/parallelism) = 4, all bookable — no OVERFLOW.
+        Calendar cal = persistCalendar("gsvc-auto", 1);
+        // slotDurationMinutes mirrors what CalendarService would persist (240min / 4 = 60).
+        persistWindow(cal, TimeWindowKind.WINDOW, SlotGenerationMode.AUTO, 8, 12, 60, 4);
+
+        List<Slot> slots = generateAndFetch(cal.id);
+
+        assertEquals(4, slots.size());
+        assertEquals(4, countByStatus(slots, SlotStatus.OPEN));
+        assertEquals(0, countByStatus(slots, SlotStatus.OVERFLOW));
+        assertTrue(slots.stream().allMatch(s -> s.capacity == 1));
+    }
+
+    @Test
+    @TestTransaction
+    void blockWindowOverridesUnbookedOverflowCells() {
+        // WINDOW (MANUAL) 08-12, 60-min slots, capacity 2 → @8 OPEN, @9 OPEN, @10 OVERFLOW, @11 OVERFLOW.
+        // BLOCK 10-12 then overrides the two unbooked OVERFLOW cells → CLOSED (and adds CLOSED cells
+        // on the 30-min block grid).
+        Calendar cal = persistCalendar("gsvc-block", 1);
+        persistWindow(cal, TimeWindowKind.WINDOW, SlotGenerationMode.MANUAL, 8, 12, 60, 2);
+        persistWindow(cal, TimeWindowKind.BLOCK, SlotGenerationMode.MANUAL, 10, 12, 30, 0);
+
+        List<Slot> slots = generateAndFetch(cal.id);
+
+        assertEquals(0, countByStatus(slots, SlotStatus.OVERFLOW), "BLOCK should override OVERFLOW cells");
+        assertEquals(2, countByStatus(slots, SlotStatus.OPEN));
+        assertTrue(countByStatus(slots, SlotStatus.CLOSED) >= 2, "the two 10:00/11:00 cells became CLOSED");
+        // The 08:00 and 09:00 slots stay OPEN.
+        assertEquals(SlotStatus.OPEN, slots.get(0).status);
+        assertEquals(8, slots.get(0).slotHour);
+        assertEquals(SlotStatus.OPEN, slots.get(1).status);
+        assertEquals(9, slots.get(1).slotHour);
+        // Everything from 10:00 on is CLOSED.
+        slots.stream()
+                .filter(s -> s.slotHour >= 10)
+                .forEach(s -> assertEquals(SlotStatus.CLOSED, s.status, "slot at " + s.slotHour + ":" + s.slotMinutes));
+    }
+}

--- a/src/test/java/com/microboxlabs/miot/calendar/validation/BookingValidationServiceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/validation/BookingValidationServiceTest.java
@@ -1,0 +1,47 @@
+package com.microboxlabs.miot.calendar.validation;
+
+import com.microboxlabs.miot.calendar.entity.Slot;
+import com.microboxlabs.miot.calendar.model.SlotStatus;
+import com.microboxlabs.miot.calendar.validation.BookingValidationService.BookingValidationException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link BookingValidationService#validateBooking}. Slot status is checked before
+ * anything that touches the database, so a plain instance suffices — no {@code @QuarkusTest} needed.
+ */
+class BookingValidationServiceTest {
+
+    private final BookingValidationService validator = new BookingValidationService();
+
+    private static Slot slotWithStatus(SlotStatus status) {
+        Slot slot = new Slot();
+        slot.status = status;
+        slot.capacity = status == SlotStatus.OVERFLOW ? 0 : 1;
+        slot.currentOccupancy = status == SlotStatus.FULL ? 1 : 0;
+        return slot;
+    }
+
+    @Test
+    void rejectsOverflowSlot() {
+        BookingValidationException ex = assertThrows(BookingValidationException.class,
+                () -> validator.validateBooking(slotWithStatus(SlotStatus.OVERFLOW), "truck-1"));
+        assertEquals("SLOT_OVERFLOW", ex.getErrorCode());
+    }
+
+    @Test
+    void rejectsClosedSlot() {
+        BookingValidationException ex = assertThrows(BookingValidationException.class,
+                () -> validator.validateBooking(slotWithStatus(SlotStatus.CLOSED), "truck-1"));
+        assertEquals("SLOT_CLOSED", ex.getErrorCode());
+    }
+
+    @Test
+    void rejectsFullSlot() {
+        BookingValidationException ex = assertThrows(BookingValidationException.class,
+                () -> validator.validateBooking(slotWithStatus(SlotStatus.FULL), "truck-1"));
+        assertEquals("SLOT_FULL", ex.getErrorCode());
+    }
+}


### PR DESCRIPTION
Backend half of #26 — per-`TimeWindow` `slotGenerationMode ∈ {AUTO, MANUAL}` so admins control slot length instead of having it derived from `capacity / parallelism`.

## Behaviour

- **AUTO** — historical behaviour: `slotDurationMinutes` derived (`numberOfSlots = ceil(capacity / parallelism)`, `duration = windowMinutes / numberOfSlots`); every generated slot is bookable.
- **MANUAL** — admin sets `slotDurationMinutes`. Then `totalSlots = floor(windowMinutes / slotDurationMinutes)`, `bookableSlots = min(ceil(capacity / parallelism), totalSlots)`; the first `bookableSlots` slots are `OPEN`, the rest are a new `SlotStatus.OVERFLOW` (rendered in the planning grid, capacity 0, bookings rejected with `SLOT_OVERFLOW`).
  - Example: 4h window + 10-min slots → 24 slots; capacity 20, parallelism 1 → 20 OPEN, 4 OVERFLOW.

New `WINDOW`s default to `MANUAL`; the V12 migration backfills existing rows to `MANUAL`, keeping their already-persisted derived `slotDurationMinutes` (behaviour-preserving for parallelism = 1 — same number of bookable slots / total bookable capacity; the only addition is a possible tail `OVERFLOW` slot when the derived duration doesn't divide the window evenly). A window can be switched back to `AUTO`, which re-derives the duration and drops any `OVERFLOW` slots.

**One intentional semantic shift:** a calendar parallelism change re-derives slot duration only for `AUTO` windows now; a `MANUAL` window keeps its admin-set duration (only the OPEN/OVERFLOW split and per-slot capacities re-lay on regen). The "repack into fewer/bigger slots on a parallelism change" behaviour is therefore `AUTO`-only — the parallelism integration tests were updated to create explicit `AUTO` windows to keep exercising that path.

## What's in this PR

- **V12 migration** — `cld_time_windows.slot_generation_mode VARCHAR(8) NOT NULL DEFAULT 'MANUAL'`; `cld_slots` status CHECK relaxed to include `'OVERFLOW'`.
- **`SlotGenerationMode`** enum; **`SlotStatus.OVERFLOW`**.
- **`TimeWindow`** — `slotGenerationMode` field + `totalSlots()` / `bookableSlots()` / `effectiveSlotDurationMinutes()` (existing `computeNumberOfSlots/computeSlotDurationMinutes/computeSlotCapacity` untouched).
- **`SlotGeneratorService`** — emits `OVERFLOW` slots beyond `bookableSlots()`; a colliding BLOCK window overrides an unbooked `OPEN`/`OVERFLOW` cell → `CLOSED`; AUTO unchanged.
- **`BookingValidationService`** — rejects `OVERFLOW` slots (`SLOT_OVERFLOW`).
- **`TimeWindowRequest`** — accepts `slotGenerationMode` + `slotDurationMinutes`; `validate()` enforces `5 ≤ slotDurationMinutes ≤ windowMinutes` for a MANUAL `WINDOW` when set (a null value is seeded server-side). **`TimeWindowResponse`** — exposes `slotGenerationMode` + derived `totalSlots` / `bookableSlots`.
- **`CalendarService`** — `createTimeWindow`/`updateTimeWindow` resolve `slotDurationMinutes` by mode (AUTO/BLOCK derive; MANUAL uses the supplied value, keeps an existing usable one, or seeds from derived); `reprocessSlotsForParallelismChange` re-derives only for AUTO windows.
- **Tests** — `SlotGeneratorServiceTest` (generator math: 24-slot/20-OPEN/4-OVERFLOW, parallelism remainder, AUTO unchanged, BLOCK-overrides-OVERFLOW, booked-slot-survives-reprocess, MANUAL→AUTO reprocess drops OVERFLOW), `BookingValidationServiceTest` (OVERFLOW/CLOSED/FULL rejection codes), `ManualSlotDurationResourceTest` (REST: explicit vs seeded duration, the [5, windowMinutes] 400s, derived `totalSlots`/`bookableSlots` on the response, AUTO→MANUAL→AUTO round trip, parallelism-change-keeps-MANUAL-duration); `Parallelism{Capacity,EdgeCase}Test` updated to create AUTO windows. `./mvnw verify` green (110 tests).

## Out of scope — follow-up issue (`modulariot` frontend)

Regenerate `miot-calendar-client` from the new `/openapi` spec → BFF zod schema (`time-windows/time-window.schema.ts`) → `time-window.service.ts` mapping → `TimeSlot` types → `quota-manager.tsx` Auto/Manual toggle + duration input + warnings + i18n (EN/ES) → `shift-layout.ts` `buildShiftLayout` `assignable` flag (needs `parallelism`) → `shift-overlay-layer.tsx` OVERFLOW rendering (neutral-grey hatch, `cursor-not-allowed`, no add-affordance) + assignment-flow guards + `SLOT_OVERFLOW` error surfacing → QA across day/week/month and AUTO↔MANUAL switches.

## Known follow-ups (warn-only in v1, per agreed decisions)

- Already-booked slots are sticky across a reprocess (`deleteUnbookedByCalendarAndDateRange` only removes `currentOccupancy = 0`), so lowering `capacity` below existing bookings, or changing the duration, leaves stale/over-cap booked slots until those bookings are deleted. Same as today for capacity/parallelism edits; the frontend will surface a warning.
- `capacity` that doesn't fit in `totalSlots` → `bookableSlots` is capped at `totalSlots`; surplus capacity is unusable (frontend warning).

Closes #26.

🤖 Driven by Claude Code (plan-loop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added slot generation mode support (AUTO and MANUAL) for time windows, enabling flexible scheduling strategies.
  * Introduced manual slot duration configuration, allowing admins to set custom slot lengths (minimum 5 minutes).
  * Added OVERFLOW slot status for slots generated beyond bookable capacity; overflow slots reject bookings.
  * Enhanced booking validation to prevent reservations in overflow slots.

* **Tests**
  * Added comprehensive test coverage for manual slot duration and slot generation behavior.

* **Chores**
  * Updated git configuration for IDE tooling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/miot-calendar/pull/27)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->