### PR TITLE
feat(calendar): cap MANUAL windows by total day bookings, not slot position

### DIFF
--- a/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
@@ -134,6 +134,14 @@ public class Booking extends PanacheEntityBase {
     }
 
     /**
+     * Count bookings made in a given time window on a given date — used to enforce a MANUAL
+     * window's total-capacity cap (the cap applies across all of the window's slots for the day).
+     */
+    public static long countByWindowAndDate(UUID timeWindowId, LocalDate date) {
+        return count("slot.timeWindow.id = ?1 and slotDate = ?2", timeWindowId, date);
+    }
+
+    /**
      * Find bookings by resource type
      */
     public static List<Booking> findByResourceType(String resourceType) {

--- a/src/main/java/com/microboxlabs/miot/calendar/entity/Slot.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/Slot.java
@@ -88,10 +88,20 @@ public class Slot extends PanacheEntityBase {
     }
 
     /**
-     * Find available slots (OPEN and not full)
+     * Find available slots (OPEN, not individually full, and — for slots that belong to a time
+     * window — whose window has not yet reached its total-capacity cap for that date). The window
+     * cap matters for MANUAL windows, where the slot grid is intentionally larger than the
+     * window's booking capacity; for AUTO windows the per-slot capacities already sum to the
+     * window capacity, so the extra predicate is a no-op there.
      */
     public static List<Slot> findAvailableByCalendarAndDateRange(UUID calendarId, LocalDate startDate, LocalDate endDate) {
-        return list("calendar.id = ?1 and slotDate >= ?2 and slotDate <= ?3 and status = ?4 and currentOccupancy < capacity order by slotDate, slotHour, slotMinutes",
+        return list("select s from Slot s left join s.timeWindow tw "
+                + "where s.calendar.id = ?1 and s.slotDate >= ?2 and s.slotDate <= ?3 "
+                + "and s.status = ?4 and s.currentOccupancy < s.capacity "
+                + "and (tw is null or "
+                + "  (select coalesce(sum(s2.currentOccupancy), 0) from Slot s2 "
+                + "   where s2.timeWindow = tw and s2.slotDate = s.slotDate) < tw.capacity) "
+                + "order by s.slotDate, s.slotHour, s.slotMinutes",
                 calendarId, startDate, endDate, SlotStatus.OPEN);
     }
 

--- a/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/TimeWindow.java
@@ -172,19 +172,22 @@ public class TimeWindow extends PanacheEntityBase {
     }
 
     /**
-     * Number of leading slots that are bookable (status OPEN). The rest, up to {@link #totalSlots()},
-     * are generated as {@link com.microboxlabs.miot.calendar.model.SlotStatus#OVERFLOW}.
-     * For AUTO this equals {@link #totalSlots()}; for MANUAL it is the capacity model's slot count
-     * ({@code ceil(capacity / parallelism)}) capped at the number of slots that fit.
+     * Number of slots that can hold bookings. Every generated slot is {@code OPEN}, so this is
+     * simply {@link #totalSlots()}. The window's total {@code capacity} is a separate cap on the
+     * day's bookings across all of its slots, enforced when a booking is created (see
+     * {@code BookingValidationService}) — not by withholding slots.
      */
     public int bookableSlots() {
-        if (kind == TimeWindowKind.BLOCK) {
-            return 0;
-        }
-        if (slotGenerationMode == SlotGenerationMode.MANUAL) {
-            return Math.min(computeNumberOfSlots(), totalSlots());
-        }
-        return computeNumberOfSlots();
+        return totalSlots();
+    }
+
+    /**
+     * Per-slot capacity for MANUAL windows: every generated slot holds up to {@code parallelism}
+     * bookings. The window-level {@code capacity} cap is enforced separately, across all of the
+     * window's slots for the day, when a booking is created (in any slot, in any order).
+     */
+    public int manualSlotCapacity() {
+        return Math.max(calendar.parallelism, 1);
     }
 
     // Finder methods

--- a/src/main/java/com/microboxlabs/miot/calendar/model/SlotGenerationMode.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/SlotGenerationMode.java
@@ -16,10 +16,11 @@ public enum SlotGenerationMode {
 
     /**
      * Slot duration is set explicitly by the admin ({@code slotDurationMinutes}). The window is
-     * filled with {@code floor(windowMinutes / slotDurationMinutes)} slots; only the first
-     * {@code ceil(capacity / parallelism)} are bookable ({@code OPEN}) — the remainder are generated
-     * as {@link SlotStatus#OVERFLOW} so the planning grid can render them, but bookings against
-     * those slots are rejected.
+     * filled with {@code floor(windowMinutes / slotDurationMinutes)} slots, all bookable
+     * ({@code OPEN}), each holding up to {@code parallelism} bookings. The window's {@code capacity}
+     * is a cap on the <em>total</em> bookings across all of its slots for the date: once that count
+     * is reached, no slot in the window accepts another booking, regardless of order. The slot grid
+     * may therefore be larger than {@code capacity} — the surplus simply stays empty.
      */
     MANUAL
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/SlotStatus.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/SlotStatus.java
@@ -23,9 +23,10 @@ public enum SlotStatus {
     CLOSED,
 
     /**
-     * Slot was generated beyond the time window's bookable quota (MANUAL slot generation):
-     * it exists so the planning grid can render it, but it carries zero capacity and bookings
-     * against it are rejected.
+     * Legacy status: previously assigned to MANUAL-mode slots generated beyond the window's
+     * bookable quota. No longer produced — MANUAL windows now emit every slot as {@code OPEN} and
+     * enforce the window's total capacity at booking time. Kept so existing rows (and the booking
+     * validator's defensive guard) still resolve; new code should not depend on it.
      */
     OVERFLOW
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowResponse.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/TimeWindowResponse.java
@@ -57,7 +57,7 @@ public record TimeWindowResponse(
     @Schema(required = true, description = "Total number of slots generated across the window (floor(windowMinutes / slotDurationMinutes) in MANUAL mode; for BLOCK windows this is 0)", minimum = "0", examples = {"24"})
     Integer totalSlots,
 
-    @Schema(required = true, description = "How many of the generated slots are bookable (OPEN); the remainder, up to totalSlots, are OVERFLOW", minimum = "0", examples = {"20"})
+    @Schema(required = true, description = "Number of slots that can hold bookings (every generated slot is OPEN, so this equals totalSlots; 0 for BLOCK windows). The window's 'capacity' is a separate cap on the total bookings across all of its slots for a date.", minimum = "0", examples = {"24"})
     Integer bookableSlots,
 
     @Schema(required = true, description = "Timestamp when the time window was created", format = "date-time")

--- a/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/CalendarService.java
@@ -179,8 +179,8 @@ public class CalendarService {
         List<TimeWindow> timeWindows = TimeWindow.findActiveByCalendarId(calendarId);
         for (TimeWindow tw : timeWindows) {
             // Only AUTO windows re-derive their slot length from the new parallelism. MANUAL windows
-            // keep the admin-set duration; their bookable/overflow split still shifts on regen because
-            // bookableSlots() = ceil(capacity / parallelism) changed.
+            // keep the admin-set duration (and slot count); the new parallelism just changes each
+            // slot's per-slot capacity on regen — the window's total-capacity cap is unchanged.
             if (tw.slotGenerationMode == SlotGenerationMode.AUTO) {
                 tw.slotDurationMinutes = tw.computeSlotDurationMinutes();
             }

--- a/src/main/java/com/microboxlabs/miot/calendar/service/SlotGeneratorService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/SlotGeneratorService.java
@@ -4,6 +4,7 @@ import com.microboxlabs.miot.calendar.entity.Calendar;
 import com.microboxlabs.miot.calendar.entity.Slot;
 import com.microboxlabs.miot.calendar.entity.TimeWindow;
 import com.microboxlabs.miot.calendar.model.GenerateSlotsResponse;
+import com.microboxlabs.miot.calendar.model.SlotGenerationMode;
 import com.microboxlabs.miot.calendar.model.SlotStatus;
 import com.microboxlabs.miot.calendar.model.TimeWindowKind;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -92,21 +93,20 @@ public class SlotGeneratorService {
         int minutes = 0;
         int slotIndex = 0;
         int step = timeWindow.effectiveSlotDurationMinutes();
-        // BLOCK fills the whole range with CLOSED cells; WINDOW emits totalSlots() slots, of which
-        // the first bookableSlots() are OPEN and the rest are OVERFLOW (MANUAL mode only — for AUTO
-        // bookableSlots() == totalSlots() so no OVERFLOW slots are produced).
+        // BLOCK fills the whole range with CLOSED cells; WINDOW emits totalSlots() slots, all OPEN.
+        // For MANUAL the grid can have more slots than the window's booking capacity — that cap is
+        // enforced at booking time (across all slots, in any order), not by withholding slots.
         int maxSlots = isBlock ? Integer.MAX_VALUE : timeWindow.totalSlots();
-        int bookable = isBlock ? 0 : timeWindow.bookableSlots();
 
         while (hour < timeWindow.endHour && slotIndex < maxSlots) {
             Slot existing = Slot.findByCalendarAndDateTime(calendar.id, date, hour, minutes);
             if (existing == null) {
-                createSlot(calendar, timeWindow, date, hour, minutes, slotIndex, bookable);
+                createSlot(calendar, timeWindow, date, hour, minutes, slotIndex);
                 counts[0]++;
             } else if (isBlock
-                    && (existing.status == SlotStatus.OPEN || existing.status == SlotStatus.OVERFLOW)
+                    && existing.status == SlotStatus.OPEN
                     && existing.currentOccupancy == 0) {
-                // BLOCK overrides an unbooked OPEN/OVERFLOW slot left by a colliding window.
+                // BLOCK overrides an unbooked OPEN slot left by a colliding window.
                 existing.status = SlotStatus.CLOSED;
                 existing.timeWindow = timeWindow;
                 existing.capacity = 0;
@@ -125,7 +125,7 @@ public class SlotGeneratorService {
     }
 
     private void createSlot(Calendar calendar, TimeWindow timeWindow,
-                            LocalDate date, int hour, int minutes, int slotIndex, int bookableSlots) {
+                            LocalDate date, int hour, int minutes, int slotIndex) {
         Slot slot = new Slot();
         slot.calendar = calendar;
         slot.timeWindow = timeWindow;
@@ -136,13 +136,14 @@ public class SlotGeneratorService {
         if (timeWindow.kind == TimeWindowKind.BLOCK) {
             slot.capacity = 0;
             slot.status = SlotStatus.CLOSED;
-        } else if (slotIndex < bookableSlots) {
-            slot.capacity = timeWindow.computeSlotCapacity(slotIndex);
-            slot.status = SlotStatus.OPEN;
         } else {
-            // Generated beyond the window's bookable quota (MANUAL mode): rendered but not bookable.
-            slot.capacity = 0;
-            slot.status = SlotStatus.OVERFLOW;
+            // Every generated slot is bookable: AUTO front-loads per-slot capacity per the
+            // parallelism model; MANUAL gives each slot the full parallelism, with the window's
+            // total capacity capped at booking time (in any slot, in any order).
+            slot.capacity = timeWindow.slotGenerationMode == SlotGenerationMode.AUTO
+                    ? timeWindow.computeSlotCapacity(slotIndex)
+                    : timeWindow.manualSlotCapacity();
+            slot.status = SlotStatus.OPEN;
         }
         slot.persist();
     }

--- a/src/main/java/com/microboxlabs/miot/calendar/validation/BookingValidationService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/validation/BookingValidationService.java
@@ -2,7 +2,10 @@ package com.microboxlabs.miot.calendar.validation;
 
 import com.microboxlabs.miot.calendar.entity.Booking;
 import com.microboxlabs.miot.calendar.entity.Slot;
+import com.microboxlabs.miot.calendar.entity.TimeWindow;
+import com.microboxlabs.miot.calendar.model.SlotGenerationMode;
 import com.microboxlabs.miot.calendar.model.SlotStatus;
+import com.microboxlabs.miot.calendar.model.TimeWindowKind;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.jboss.logging.Logger;
 
@@ -24,14 +27,17 @@ public class BookingValidationService {
     public void validateBooking(Slot slot, String resourceId) {
         // 1. Check slot status
         validateSlotStatus(slot);
-        
-        // 2. Check slot capacity
+
+        // 2. Check the parent window's total-capacity cap (MANUAL windows)
+        validateWindowCapacity(slot);
+
+        // 3. Check slot capacity
         validateSlotCapacity(slot);
-        
-        // 3. Check resource not already in slot
+
+        // 4. Check resource not already in slot
         validateResourceNotInSlot(slot, resourceId);
         
-        // 4. Optional: Check resource not already booked on same day
+        // 5. Optional: Check resource not already booked on same day
         // This is commented out as it may not always be required
         // validateResourceNotBookedOnDate(slot.slotDate, resourceId);
         
@@ -58,6 +64,31 @@ public class BookingValidationService {
             throw new BookingValidationException(
                 "Slot is at full capacity",
                 "SLOT_FULL"
+            );
+        }
+    }
+
+    /**
+     * Validate the parent time window's total-capacity cap.
+     *
+     * <p>For MANUAL windows the slot grid is intentionally larger than the window's booking
+     * capacity. The cap is on the <em>total</em> bookings across all of the window's slots for the
+     * date — once that count is reached, no slot in the window accepts another booking, regardless
+     * of order or of the target slot's own remaining room. AUTO windows are sized so that the slot
+     * capacities sum exactly to the window capacity, so they need no extra check.
+     */
+    private void validateWindowCapacity(Slot slot) {
+        TimeWindow tw = slot.timeWindow;
+        if (tw == null || tw.kind != TimeWindowKind.WINDOW
+                || tw.slotGenerationMode != SlotGenerationMode.MANUAL) {
+            return;
+        }
+        long dayTotal = Booking.countByWindowAndDate(tw.id, slot.slotDate);
+        if (dayTotal >= tw.capacity) {
+            throw new BookingValidationException(
+                String.format("Time window '%s' is full for %s (%d/%d)",
+                    tw.name, slot.slotDate, dayTotal, tw.capacity),
+                "WINDOW_CAPACITY_REACHED"
             );
         }
     }

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/ManualSlotDurationResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/ManualSlotDurationResourceTest.java
@@ -71,14 +71,14 @@ class ManualSlotDurationResourceTest {
     @Test
     void createsManualWindowWithExplicitDurationAndDerivedSlotCounts() {
         String calendarId = createCalendar("msd-explicit", 1);
-        // 4h window, 10-min slots → 24 slots fit; capacity 20, parallelism 1 → 20 OPEN, 4 OVERFLOW.
+        // 4h window, 10-min slots → 24 slots fit; all OPEN. capacity 20 is a separate booking cap.
         given().contentType(ContentType.JSON).body(timeWindowBody("MANUAL", 10, 8, 12, 20))
             .when().post(CALENDARS_PATH + "/" + calendarId + "/time-windows")
             .then().statusCode(201)
             .body("slotGenerationMode", equalTo("MANUAL"))
             .body("slotDurationMinutes", equalTo(10))
             .body("totalSlots", equalTo(24))
-            .body("bookableSlots", equalTo(20));
+            .body("bookableSlots", equalTo(24));
     }
 
     @Test
@@ -133,10 +133,10 @@ class ManualSlotDurationResourceTest {
             .when().put(twPath)
             .then().statusCode(200)
             .body("slotDurationMinutes", equalTo(20))
-            .body("totalSlots", equalTo(12))     // 240 / 20
-            .body("bookableSlots", equalTo(4));  // ceil(4/1), capped at 12
+            .body("totalSlots", equalTo(12))      // 240 / 20
+            .body("bookableSlots", equalTo(12));  // every slot is bookable; capacity 4 caps total bookings
 
-        // MANUAL → AUTO: duration re-derived, OVERFLOW gone (bookableSlots == totalSlots).
+        // MANUAL → AUTO: duration re-derived (bookableSlots stays == totalSlots).
         given().contentType(ContentType.JSON).body("{ \"slotGenerationMode\": \"AUTO\" }")
             .when().put(twPath)
             .then().statusCode(200)
@@ -149,15 +149,16 @@ class ManualSlotDurationResourceTest {
     @Test
     void parallelismChangeLeavesManualWindowDurationUntouched() {
         String calendarId = createCalendar("msd-par-keep", 1);
-        // MANUAL 30-min slots over a 4h window: 8 slots fit; capacity 4, parallelism 1 → 4 OPEN + 4 OVERFLOW.
+        // MANUAL 30-min slots over a 4h window: 8 slots fit; all OPEN. capacity 4 caps total bookings.
         given().contentType(ContentType.JSON).body(timeWindowBody("MANUAL", 30, 8, 12, 4))
             .when().post(CALENDARS_PATH + "/" + calendarId + "/time-windows")
             .then().statusCode(201)
             .body("slotDurationMinutes", equalTo(30))
             .body("totalSlots", equalTo(8))
-            .body("bookableSlots", equalTo(4));
+            .body("bookableSlots", equalTo(8));
 
-        // Bump parallelism — a MANUAL window keeps its duration; only bookableSlots re-lays.
+        // Bump parallelism — a MANUAL window keeps its duration and slot count untouched
+        // (parallelism only changes each slot's per-slot capacity on regen).
         given().contentType(ContentType.JSON).body("{ \"parallelism\": 2 }")
             .when().put(CALENDARS_PATH + "/" + calendarId)
             .then().statusCode(200).body("parallelism", equalTo(2));
@@ -167,6 +168,6 @@ class ManualSlotDurationResourceTest {
             .body("[0].slotGenerationMode", equalTo("MANUAL"))
             .body("[0].slotDurationMinutes", equalTo(30))  // unchanged
             .body("[0].totalSlots", equalTo(8))            // unchanged
-            .body("[0].bookableSlots", equalTo(2));        // ceil(4/2)
+            .body("[0].bookableSlots", equalTo(8));        // unchanged (== totalSlots)
     }
 }

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/ManualWindowCapacityResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/ManualWindowCapacityResourceTest.java
@@ -1,0 +1,133 @@
+package com.microboxlabs.miot.calendar.resource;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.time.LocalDate;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * End-to-end coverage for the MANUAL time-window total-capacity cap: the slot grid is intentionally
+ * larger than the window's {@code capacity}, every slot is bookable, and a booking is rejected
+ * (anywhere in the window, even into a partially-full slot) once the day's total bookings reach
+ * {@code capacity}. Cancelling a booking re-opens the window.
+ */
+@QuarkusTest
+class ManualWindowCapacityResourceTest {
+
+    private static final String CALENDARS_PATH = "/api/v1/miot-calendar/calendars";
+    private static final String SLOTS_GENERATE_PATH = "/api/v1/miot-calendar/slots/generate";
+    private static final String BOOKINGS_PATH = "/api/v1/miot-calendar/bookings";
+    /** Tomorrow — matches the window's daysOfWeek "1..7" and is >= validFrom (today). */
+    private static final LocalDate SLOT_DATE = LocalDate.now().plusDays(1);
+
+    @TestHTTPResource
+    URL url;
+
+    @BeforeEach
+    void setupRestAssured() {
+        RestAssured.baseURI = url.toString();
+        RestAssured.port = url.getPort();
+    }
+
+    private String createCalendarWithManualWindow(String code) {
+        String calendarId = given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                { "code": "%s", "name": "%s", "parallelism": 2 }
+                """, code, code))
+            .when().post(CALENDARS_PATH)
+            .then().statusCode(201)
+            .extract().path("id");
+
+        // MANUAL 08-12 (240 min), 30-min slots → 8 slots, each capacity = parallelism (2);
+        // window capacity = 4 → only 4 bookings total fit (the 4 surplus cells stay empty).
+        given().contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "name": "Capped Window",
+                    "slotGenerationMode": "MANUAL",
+                    "slotDurationMinutes": 30,
+                    "startHour": 8,
+                    "endHour": 12,
+                    "capacity": 4,
+                    "daysOfWeek": "1,2,3,4,5,6,7",
+                    "validFrom": "%s"
+                }
+                """, LocalDate.now()))
+            .when().post(CALENDARS_PATH + "/" + calendarId + "/time-windows")
+            .then().statusCode(201)
+            .body("totalSlots", equalTo(8))
+            .body("bookableSlots", equalTo(8));
+
+        given().contentType(ContentType.JSON)
+            .body(String.format("""
+                { "calendarId": "%s", "startDate": "%s", "endDate": "%s" }
+                """, calendarId, SLOT_DATE, SLOT_DATE))
+            .when().post(SLOTS_GENERATE_PATH)
+            .then().statusCode(200);
+
+        return calendarId;
+    }
+
+    private Response book(String calendarId, String resourceId, int hour, int minutes) {
+        return given().contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "calendarId": "%s",
+                    "resource": { "id": "%s", "type": "SERVICE", "label": "%s" },
+                    "slot": { "date": "%s", "hour": %d, "minutes": %d }
+                }
+                """, calendarId, resourceId, resourceId, SLOT_DATE, hour, minutes))
+            .when().post(BOOKINGS_PATH)
+            .thenReturn();
+    }
+
+    private String bookOk(String calendarId, String resourceId, int hour, int minutes) {
+        return book(calendarId, resourceId, hour, minutes)
+            .then().statusCode(201)
+            .extract().path("id");
+    }
+
+    @Test
+    void rejectsBookingsBeyondWindowCapacityRegardlessOfSlot() {
+        String calendarId = createCalendarWithManualWindow("mwc-reject");
+
+        // 4 bookings scattered across the grid: 2 into the 08:00 slot (fills it), 1 @09:00, 1 @10:00.
+        bookOk(calendarId, "R1", 8, 0);
+        bookOk(calendarId, "R2", 8, 0);
+        bookOk(calendarId, "R3", 9, 0);
+        bookOk(calendarId, "R4", 10, 0);
+
+        // 5th into a still-empty slot → window is full for the day.
+        book(calendarId, "R5", 11, 0).then().statusCode(409);
+        // 5th into a partially-full slot (09:00 has room: 1/2) → still rejected; the cap is on the
+        // window's total bookings, in any slot, in any order.
+        book(calendarId, "R6", 9, 30).then().statusCode(409);
+    }
+
+    @Test
+    void cancellingABookingReopensTheWindow() {
+        String calendarId = createCalendarWithManualWindow("mwc-reopen");
+
+        bookOk(calendarId, "R1", 8, 0);
+        bookOk(calendarId, "R2", 8, 30);
+        bookOk(calendarId, "R3", 9, 0);
+        String fourth = bookOk(calendarId, "R4", 9, 30);
+
+        book(calendarId, "R5", 10, 0).then().statusCode(409);
+
+        given().when().delete(BOOKINGS_PATH + "/" + fourth).then().statusCode(204);
+
+        // A slot freed up — the next booking (anywhere) succeeds again.
+        bookOk(calendarId, "R5", 10, 0);
+    }
+}

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/ManualWindowCapacityResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/ManualWindowCapacityResourceTest.java
@@ -48,8 +48,9 @@ class ManualWindowCapacityResourceTest {
             .then().statusCode(201)
             .extract().path("id");
 
-        // MANUAL 08-12 (240 min), 30-min slots → 8 slots, each capacity = parallelism (2);
-        // window capacity = 4 → only 4 bookings total fit (the 4 surplus cells stay empty).
+        // A MANUAL 08-12 window (240 minutes) with 30-minute slots fits 8 slots; each slot holds
+        // up to parallelism bookings (2 in this calendar). The window capacity is 4, so only 4
+        // bookings total fit across the day — the 4 surplus cells stay empty.
         given().contentType(ContentType.JSON)
             .body(String.format("""
                 {

--- a/src/test/java/com/microboxlabs/miot/calendar/service/SlotGeneratorServiceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/service/SlotGeneratorServiceTest.java
@@ -22,13 +22,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Generator-level tests for MANUAL slot generation: slots beyond the window's bookable quota are
- * emitted as {@link SlotStatus#OVERFLOW} (rendered, capacity 0, not bookable), AUTO behaviour is
- * unchanged, and a colliding BLOCK window overrides an unbooked OVERFLOW cell to CLOSED.
+ * Generator-level tests for slot generation. MANUAL windows emit {@code floor(windowMinutes /
+ * slotDurationMinutes)} slots, all {@code OPEN}, each carrying {@code parallelism} capacity — the
+ * window's total-capacity cap is enforced at booking time, not by withholding slots. AUTO behaviour
+ * is unchanged, and a colliding BLOCK window still overrides an unbooked OPEN cell to CLOSED.
  *
- * <p>These exercise {@link SlotGeneratorService} directly (the REST layer can't configure a MANUAL
- * window until the time-window DTOs are wired). Each test runs inside a {@link TestTransaction} that
- * rolls back, so persisted fixtures never leak between tests.
+ * <p>These exercise {@link SlotGeneratorService} directly. Each test runs inside a
+ * {@link TestTransaction} that rolls back, so persisted fixtures never leak between tests.
  */
 @QuarkusTest
 class SlotGeneratorServiceTest {
@@ -78,28 +78,18 @@ class SlotGeneratorServiceTest {
 
     @Test
     @TestTransaction
-    void manualWindowEmitsOpenSlotsThenOverflow() {
-        // 4h window, 10-min slots → 24 slots fit; capacity 20, parallelism 1 → 20 OPEN + 4 OVERFLOW.
-        Calendar cal = persistCalendar("gsvc-overflow", 1);
+    void manualWindowEmitsEverySlotOpen() {
+        // 4h window, 10-min slots → 24 slots fit; capacity 20, parallelism 1 → all 24 OPEN, capacity 1.
+        Calendar cal = persistCalendar("gsvc-manual", 1);
         persistWindow(cal, TimeWindowKind.WINDOW, SlotGenerationMode.MANUAL, 8, 12, 10, 20);
 
         List<Slot> slots = generateAndFetch(cal.id);
 
         assertEquals(24, slots.size(), "floor(240min / 10min) slots");
-        assertEquals(20, countByStatus(slots, SlotStatus.OPEN));
-        assertEquals(4, countByStatus(slots, SlotStatus.OVERFLOW));
+        assertEquals(24, countByStatus(slots, SlotStatus.OPEN));
+        assertEquals(0, countByStatus(slots, SlotStatus.OVERFLOW));
         assertEquals(0, countByStatus(slots, SlotStatus.CLOSED));
-        // First 20 are OPEN with capacity 1; last 4 are OVERFLOW with capacity 0.
-        for (int i = 0; i < slots.size(); i++) {
-            Slot s = slots.get(i);
-            if (i < 20) {
-                assertEquals(SlotStatus.OPEN, s.status, "slot " + i);
-                assertEquals(1, s.capacity, "slot " + i + " capacity");
-            } else {
-                assertEquals(SlotStatus.OVERFLOW, s.status, "slot " + i);
-                assertEquals(0, s.capacity, "slot " + i + " capacity");
-            }
-        }
+        assertTrue(slots.stream().allMatch(s -> s.capacity == 1), "every MANUAL slot carries parallelism (1)");
         // First slot at 08:00, last at 08:00 + 23*10min = 11:50.
         assertEquals(8, slots.get(0).slotHour);
         assertEquals(0, slots.get(0).slotMinutes);
@@ -109,20 +99,18 @@ class SlotGeneratorServiceTest {
 
     @Test
     @TestTransaction
-    void manualWindowRespectsParallelismRemainderOnTheLastBookableSlot() {
-        // 4h window, 30-min slots → 8 slots fit; capacity 7, parallelism 2 → ceil(7/2)=4 bookable
-        // with capacities [2,2,2,1]; the remaining 4 slots are OVERFLOW.
-        Calendar cal = persistCalendar("gsvc-remainder", 2);
+    void manualSlotCapacityEqualsParallelism() {
+        // 4h window, 30-min slots → 8 slots fit; capacity 7, parallelism 2 → all 8 OPEN, capacity 2.
+        // (The window cap of 7 is enforced at booking time, not by shrinking per-slot capacity.)
+        Calendar cal = persistCalendar("gsvc-parallelism", 2);
         persistWindow(cal, TimeWindowKind.WINDOW, SlotGenerationMode.MANUAL, 8, 12, 30, 7);
 
         List<Slot> slots = generateAndFetch(cal.id);
 
         assertEquals(8, slots.size());
-        assertEquals(List.of(2, 2, 2, 1, 0, 0, 0, 0), slots.stream().map(s -> s.capacity).toList());
-        assertEquals(4, countByStatus(slots, SlotStatus.OPEN));
-        assertEquals(4, countByStatus(slots, SlotStatus.OVERFLOW));
-        for (int i = 0; i < 4; i++) assertEquals(SlotStatus.OPEN, slots.get(i).status, "slot " + i);
-        for (int i = 4; i < 8; i++) assertEquals(SlotStatus.OVERFLOW, slots.get(i).status, "slot " + i);
+        assertEquals(8, countByStatus(slots, SlotStatus.OPEN));
+        assertEquals(0, countByStatus(slots, SlotStatus.OVERFLOW));
+        assertTrue(slots.stream().allMatch(s -> s.capacity == 2));
     }
 
     @Test
@@ -143,20 +131,33 @@ class SlotGeneratorServiceTest {
 
     @Test
     @TestTransaction
-    void blockWindowOverridesUnbookedOverflowCells() {
-        // WINDOW (MANUAL) 08-12, 60-min slots, capacity 2 → @8 OPEN, @9 OPEN, @10 OVERFLOW, @11 OVERFLOW.
-        // BLOCK 10-12 then overrides the two unbooked OVERFLOW cells → CLOSED (and adds CLOSED cells
-        // on the 30-min block grid).
+    void autoWindowFrontLoadsParallelismRemainderOnTheLastSlot() {
+        // AUTO 4h window, capacity 7, parallelism 2 → ceil(7/2)=4 slots with capacities [2,2,2,1].
+        Calendar cal = persistCalendar("gsvc-auto-remainder", 2);
+        persistWindow(cal, TimeWindowKind.WINDOW, SlotGenerationMode.AUTO, 8, 12, 60, 7);
+
+        List<Slot> slots = generateAndFetch(cal.id);
+
+        assertEquals(4, slots.size());
+        assertEquals(List.of(2, 2, 2, 1), slots.stream().map(s -> s.capacity).toList());
+        assertTrue(slots.stream().allMatch(s -> s.status == SlotStatus.OPEN));
+    }
+
+    @Test
+    @TestTransaction
+    void blockWindowOverridesUnbookedOpenCells() {
+        // WINDOW (MANUAL) 08-12, 60-min slots, capacity 2 → four OPEN cells @8/@9/@10/@11.
+        // BLOCK 10-12 then overrides the two unbooked 10:00/11:00 cells → CLOSED (and adds CLOSED
+        // cells on the 30-min block grid).
         Calendar cal = persistCalendar("gsvc-block", 1);
         persistWindow(cal, TimeWindowKind.WINDOW, SlotGenerationMode.MANUAL, 8, 12, 60, 2);
         persistWindow(cal, TimeWindowKind.BLOCK, SlotGenerationMode.MANUAL, 10, 12, 30, 0);
 
         List<Slot> slots = generateAndFetch(cal.id);
 
-        assertEquals(0, countByStatus(slots, SlotStatus.OVERFLOW), "BLOCK should override OVERFLOW cells");
-        assertEquals(2, countByStatus(slots, SlotStatus.OPEN));
+        assertEquals(0, countByStatus(slots, SlotStatus.OVERFLOW));
+        assertEquals(2, countByStatus(slots, SlotStatus.OPEN), "08:00 and 09:00 stay OPEN");
         assertTrue(countByStatus(slots, SlotStatus.CLOSED) >= 2, "the two 10:00/11:00 cells became CLOSED");
-        // The 08:00 and 09:00 slots stay OPEN.
         assertEquals(SlotStatus.OPEN, slots.get(0).status);
         assertEquals(8, slots.get(0).slotHour);
         assertEquals(SlotStatus.OPEN, slots.get(1).status);
@@ -175,7 +176,7 @@ class SlotGeneratorServiceTest {
         TimeWindow tw = persistWindow(cal, TimeWindowKind.WINDOW, SlotGenerationMode.MANUAL, 8, 12, 30, 8);
         slotGeneratorService.generateSlots(cal.id, A_MONDAY, A_MONDAY);
 
-        // Simulate a booking on the 08:00 slot, then drop the window capacity (bookable → ceil(2/1) = 2).
+        // Simulate a booking on the 08:00 slot, then drop the window capacity to 2.
         Slot first = Slot.findByCalendarAndDateTime(cal.id, A_MONDAY, 8, 0);
         first.currentOccupancy = 1;
         tw.capacity = 2;
@@ -185,22 +186,23 @@ class SlotGeneratorServiceTest {
         slotGeneratorService.generateSlots(cal.id, A_MONDAY, A_MONDAY, true); // reprocess: drop unbooked, regenerate
 
         List<Slot> slots = Slot.findByCalendarAndDateRange(cal.id, A_MONDAY, A_MONDAY);
-        assertEquals(8, slots.size(), "8 slots still fit the window regardless of the lowered bookable count");
+        assertEquals(8, slots.size(), "8 slots still fit the window regardless of the lowered capacity cap");
+        assertEquals(0, countByStatus(slots, SlotStatus.OVERFLOW));
+        assertTrue(slots.stream().allMatch(s -> s.status == SlotStatus.OPEN));
         Slot surviving = slots.stream()
                 .filter(s -> s.slotHour == 8 && s.slotMinutes == 0)
                 .findFirst().orElseThrow();
         assertEquals(1, surviving.currentOccupancy, "the booked slot is preserved across the reprocess");
-        assertEquals(6, countByStatus(slots, SlotStatus.OVERFLOW), "slots beyond the lowered bookable quota become OVERFLOW");
     }
 
     @Test
     @TestTransaction
-    void manualToAutoReprocessDropsOverflowSlots() {
-        // MANUAL 4h/10-min/cap20/p1 → 24 slots, 4 of them OVERFLOW.
+    void manualToAutoReprocessShrinksSlotGrid() {
+        // MANUAL 4h/10-min/cap20/p1 → 24 OPEN slots.
         Calendar cal = persistCalendar("gsvc-m2a", 1);
         TimeWindow tw = persistWindow(cal, TimeWindowKind.WINDOW, SlotGenerationMode.MANUAL, 8, 12, 10, 20);
         slotGeneratorService.generateSlots(cal.id, A_MONDAY, A_MONDAY);
-        assertEquals(4, countByStatus(Slot.findByCalendarAndDateRange(cal.id, A_MONDAY, A_MONDAY), SlotStatus.OVERFLOW));
+        assertEquals(24, Slot.findByCalendarAndDateRange(cal.id, A_MONDAY, A_MONDAY).size());
 
         // Switch to AUTO (mimic CalendarService: re-derive the duration), then reprocess.
         tw.slotGenerationMode = SlotGenerationMode.AUTO;
@@ -211,8 +213,8 @@ class SlotGeneratorServiceTest {
         slotGeneratorService.generateSlots(cal.id, A_MONDAY, A_MONDAY, true);
 
         List<Slot> slots = Slot.findByCalendarAndDateRange(cal.id, A_MONDAY, A_MONDAY);
-        assertEquals(0, countByStatus(slots, SlotStatus.OVERFLOW), "AUTO never produces OVERFLOW slots");
-        assertEquals(20, slots.size());
+        assertEquals(20, slots.size(), "AUTO sizes the grid to ceil(capacity/parallelism)");
+        assertEquals(0, countByStatus(slots, SlotStatus.OVERFLOW));
         assertTrue(slots.stream().allMatch(s -> s.status == SlotStatus.OPEN));
     }
 }


### PR DESCRIPTION
## What

Reworks MANUAL slot generation so unbookable slots are no longer the *last N by position*. Instead:

- Every generated slot is `OPEN` and holds up to `parallelism` bookings.
- The window's `capacity` is a cap on the **total bookings across all of the window's slots for a date**, enforced at booking time — in any slot, in any order.
- Once that count is reached, any further booking (even into a partially-full slot) is rejected with `WINDOW_CAPACITY_REACHED`. Cancelling a booking re-opens the window.
- The slot grid may be larger than `capacity`; the surplus simply stays empty.

This replaces the positional `OVERFLOW` model from the original 0.5.0 manual-slot-duration feature, per product feedback ("disable slots only when current planned services == capacity, in any order").

## Changes

- **`TimeWindow`** — `bookableSlots()` now equals `totalSlots()`; new `manualSlotCapacity()` (= `max(parallelism, 1)`).
- **`SlotGeneratorService`** — every WINDOW slot is emitted `OPEN`; AUTO front-loads per-slot capacity per the parallelism model, MANUAL uses flat `parallelism`. No more `OVERFLOW` emission. BLOCK still overrides unbooked `OPEN` cells to `CLOSED`.
- **`BookingValidationService`** — new `validateWindowCapacity()` rejects over-cap bookings for MANUAL windows via `Booking.countByWindowAndDate(timeWindowId, date)`.
- **`Slot.findAvailableByCalendarAndDateRange`** — now window-cap-aware (`left join s.timeWindow tw` + correlated `sum(currentOccupancy) < tw.capacity`) so the public availability API stops over-reporting MANUAL "spare" slots.
- **`SlotStatus.OVERFLOW`** — kept as a legacy/no-longer-produced enum value; the validator keeps a defensive guard so any pre-existing rows still resolve. (No migration — a `?reprocess=true` slot regeneration converts old grids.)
- Docs/schemas updated (`SlotGenerationMode`, `SlotStatus`, `TimeWindowResponse`, `CalendarService` comment).
- **Tests** — `SlotGeneratorServiceTest` / `ManualSlotDurationResourceTest` expectations updated to all-`OPEN` (`bookableSlots == totalSlots`); new `ManualWindowCapacityResourceTest` covering scattered fill to capacity, rejection into a still-empty *and* a partially-full slot, and cancel-re-opens.

## Notes

- Amends the 0.5.0 manual-slot-duration feature (unreleased) — no version bump.
- Frontend follow-up (separate PR in `modulariot`): the planner derives the "window full" lock client-side from planned services and stops using the positional `assignable` flag.

## Validation

`./mvnw -q verify` — green (113 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time-window capacity is now enforced on a daily basis across all slots, rejecting bookings that exceed the window's capacity limit.

* **Bug Fixes**
  * Corrected availability queries to properly evaluate capacity constraints at the window level.

* **Tests**
  * Added tests for time-window capacity enforcement.
  * Updated tests to reflect new slot availability behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/miot-calendar/pull/28)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->