### PR TITLE
feat(api): reprocess flag on POST /slots/generate (+ 0.5.1 version bump)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microboxlabs</groupId>
     <artifactId>miot-calendar</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
     <packaging>jar</packaging>
 
     <name>MIOT Calendar</name>

--- a/src/main/java/com/microboxlabs/miot/calendar/model/GenerateSlotsRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/GenerateSlotsRequest.java
@@ -17,8 +17,16 @@ public record GenerateSlotsRequest(
     LocalDate startDate,
 
     @Schema(required = true, description = "End date of the generation range (inclusive, max 90 days from start)", format = "date", examples = {"2025-06-30"})
-    LocalDate endDate
+    LocalDate endDate,
+
+    @Schema(description = "If true, delete all unbooked slots in the range and regenerate them with the current time-window config — useful after a config change or to convert legacy OVERFLOW rows produced by an older deploy. Booked slots are preserved. Defaults to false (gaps only).", defaultValue = "false")
+    Boolean reprocess
 ) {
+    /** Absent in the payload ⇒ false. */
+    public boolean reprocessOrDefault() {
+        return Boolean.TRUE.equals(reprocess);
+    }
+
     /**
      * Validate the generate slots request
      */

--- a/src/main/java/com/microboxlabs/miot/calendar/resource/SlotResource.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/resource/SlotResource.java
@@ -90,7 +90,8 @@ public class SlotResource {
     @POST
     @Path("/generate")
     @Transactional
-    @Operation(operationId = "generateSlots", summary = "Generate slots", description = "Generate booking slots for a calendar within a date range based on its time window configurations. Existing slots are skipped.")
+    @Operation(operationId = "generateSlots", summary = "Generate slots",
+        description = "Generate booking slots for a calendar within a date range based on its time window configurations. By default, existing slots are skipped (only gaps are filled). Pass `reprocess: true` to delete all unbooked slots in the range and regenerate them with the current config — useful after a time-window change or to convert legacy OVERFLOW rows produced by an older deploy. Booked slots are always preserved.")
     @APIResponse(responseCode = "200", description = "Slots generated successfully",
         content = @Content(schema = @Schema(implementation = GenerateSlotsResponse.class)))
     @APIResponse(responseCode = "400", description = "Invalid request",
@@ -101,7 +102,8 @@ public class SlotResource {
             GenerateSlotsResponse response = slotGeneratorService.generateSlots(
                 request.calendarId(),
                 request.startDate(),
-                request.endDate()
+                request.endDate(),
+                request.reprocessOrDefault()
             );
             return Response.ok(response).build();
         } catch (IllegalArgumentException e) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ quarkus.hibernate-orm.mapping.format.global=ignore
 
 # OpenAPI / Swagger
 quarkus.smallrye-openapi.info-title=MIOT Calendar API
-quarkus.smallrye-openapi.info-version=0.5.0
+quarkus.smallrye-openapi.info-version=0.5.1
 quarkus.smallrye-openapi.info-description=Calendar booking microservice for resource scheduling. Provides calendar management, time window configuration, slot generation, and booking operations.
 quarkus.smallrye-openapi.info-contact-name=MicroBoxLabs
 quarkus.smallrye-openapi.info-contact-url=https://microboxlabs.com

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/SlotGenerateReprocessTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/SlotGenerateReprocessTest.java
@@ -1,0 +1,143 @@
+package com.microboxlabs.miot.calendar.resource;
+
+import com.microboxlabs.miot.calendar.entity.Calendar;
+import com.microboxlabs.miot.calendar.entity.Slot;
+import com.microboxlabs.miot.calendar.entity.TimeWindow;
+import com.microboxlabs.miot.calendar.model.SlotGenerationMode;
+import com.microboxlabs.miot.calendar.model.SlotStatus;
+import com.microboxlabs.miot.calendar.model.TimeWindowKind;
+import io.quarkus.hibernate.orm.panache.Panache;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import java.util.UUID;
+
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises the {@code reprocess} flag on {@code POST /slots/generate}: omitted/false leaves
+ * existing rows alone (gap-fill semantics), {@code true} deletes unbooked rows and regenerates them
+ * with the current config. The latter is the supported way to convert legacy {@code OVERFLOW}
+ * rows (produced before the count-based window cap) to {@code OPEN} without a SQL migration.
+ */
+@QuarkusTest
+class SlotGenerateReprocessTest {
+
+    private static final String SLOTS_GENERATE_PATH = "/api/v1/miot-calendar/slots/generate";
+    /** A future Monday — matches the window's daysOfWeek="1" and is >= validFrom (today). */
+    private static final LocalDate A_MONDAY =
+            LocalDate.now().with(TemporalAdjusters.next(DayOfWeek.MONDAY));
+
+    @TestHTTPResource
+    URL url;
+
+    @BeforeEach
+    void setupRestAssured() {
+        RestAssured.baseURI = url.toString();
+        RestAssured.port = url.getPort();
+    }
+
+    /**
+     * Seed a calendar + MANUAL time window and persist a single legacy OVERFLOW slot row
+     * (mimicking what an older deploy would have written). Wrapped in a TX so the seed is
+     * flushed before the REST call runs.
+     */
+    @Transactional
+    UUID seedCalendarWithLegacyOverflowSlot(String code, int hour) {
+        Calendar cal = new Calendar();
+        cal.code = code;
+        cal.name = code;
+        cal.parallelism = 2;
+        cal.persist();
+
+        TimeWindow tw = new TimeWindow();
+        tw.calendar = cal;
+        tw.name = "manual-window";
+        tw.kind = TimeWindowKind.WINDOW;
+        tw.slotGenerationMode = SlotGenerationMode.MANUAL;
+        tw.startHour = 8;
+        tw.endHour = 12;
+        tw.slotDurationMinutes = 30;
+        tw.capacity = 4;
+        tw.daysOfWeek = "1";
+        tw.validFrom = LocalDate.now();
+        tw.active = true;
+        tw.persist();
+
+        Slot legacy = new Slot();
+        legacy.calendar = cal;
+        legacy.timeWindow = tw;
+        legacy.slotDate = A_MONDAY;
+        legacy.slotHour = hour;
+        legacy.slotMinutes = 0;
+        legacy.capacity = 0;
+        legacy.currentOccupancy = 0;
+        legacy.status = SlotStatus.OVERFLOW;
+        legacy.persist();
+
+        Panache.getEntityManager().flush();
+        return cal.id;
+    }
+
+    @Test
+    void reprocessFalseLeavesExistingOverflowRowAlone() {
+        UUID calendarId = seedCalendarWithLegacyOverflowSlot("gen-reproc-skip", 9);
+
+        // Default behaviour: no reprocess field. Existing slots are skipped; the legacy OVERFLOW
+        // row at 09:00 is reported in slotsSkipped and survives untouched.
+        given().contentType(ContentType.JSON)
+            .body(String.format("""
+                { "calendarId": "%s", "startDate": "%s", "endDate": "%s" }
+                """, calendarId, A_MONDAY, A_MONDAY))
+            .when().post(SLOTS_GENERATE_PATH)
+            .then().statusCode(200)
+            .body("slotsCreated", greaterThan(0))   // the other 7 slots get created
+            .body("slotsSkipped", equalTo(1));      // the legacy 09:00 OVERFLOW row
+
+        Slot at9 = Slot.findByCalendarAndDateTime(calendarId, A_MONDAY, 9, 0);
+        assertEquals(SlotStatus.OVERFLOW, at9.status,
+                "without reprocess, the legacy OVERFLOW row is preserved verbatim");
+        assertEquals(0, at9.capacity);
+    }
+
+    @Test
+    void reprocessTrueConvertsLegacyOverflowRowToOpen() {
+        UUID calendarId = seedCalendarWithLegacyOverflowSlot("gen-reproc-fix", 10);
+
+        // reprocess=true drops unbooked slots in range and regenerates them with the current
+        // config — every MANUAL slot becomes OPEN with capacity = parallelism (2).
+        given().contentType(ContentType.JSON)
+            .body(String.format("""
+                { "calendarId": "%s", "startDate": "%s", "endDate": "%s", "reprocess": true }
+                """, calendarId, A_MONDAY, A_MONDAY))
+            .when().post(SLOTS_GENERATE_PATH)
+            .then().statusCode(200)
+            .body("slotsCreated", equalTo(8));      // 240 min / 30 min = 8 slots, all regenerated
+
+        Slot at10 = Slot.findByCalendarAndDateTime(calendarId, A_MONDAY, 10, 0);
+        assertEquals(SlotStatus.OPEN, at10.status,
+                "reprocess regenerated the legacy OVERFLOW row as OPEN");
+        assertEquals(2, at10.capacity, "capacity = calendar parallelism");
+
+        // Every slot in the window is now OPEN with capacity 2 — no leftover OVERFLOW.
+        List<Slot> all = Slot.findByCalendarAndDateRange(calendarId, A_MONDAY, A_MONDAY);
+        assertEquals(8, all.size());
+        assertTrue(all.stream().allMatch(s -> s.status == SlotStatus.OPEN));
+        assertTrue(all.stream().allMatch(s -> s.capacity == 2));
+    }
+}


### PR DESCRIPTION
Follow-up to #28. Two small changes left out of the original merge:

## What

### 1. New `reprocess` flag on `POST /slots/generate` (`43c396a`)

Exposes `SlotGeneratorService`'s existing 4-arg `reprocess` overload at the REST layer so operators can regenerate unbooked slots in a range from the current time-window config — useful after a config change or **to convert legacy `OVERFLOW` rows** (produced before #28 landed) to `OPEN`/parallelism without a SQL migration.

```json
POST /api/v1/miot-calendar/slots/generate
{
  "calendarId": "<uuid>",
  "startDate":  "2026-05-13",
  "endDate":    "2026-08-11",
  "reprocess":  true
}
```

- Absent / `false` → unchanged "gap-fill only" semantics (fully backward compatible).
- `true` → deletes **unbooked** slots in range and regenerates them with the live config. Booked slots are always preserved.

Files: `GenerateSlotsRequest` (new optional field + `reprocessOrDefault()` accessor), `SlotResource.generateSlots` (forwards the flag, OpenAPI summary updated), new `SlotGenerateReprocessTest` (REST-level coverage of both branches, including the legacy-OVERFLOW → OPEN conversion).

### 2. Version bump `0.5.0` → `0.5.1` (`992c8b9`)

The trunk `mvn deploy` step was hitting `409 Conflict` against GitHub Packages because `0.5.0` was already published from the original manual-slot-duration release. `pom.xml` + `application.properties` `info-version` updated; no DTO surface change; `WINDOW_CAPACITY_REACHED` from #28 is an additive error code.

## Validation

`./mvnw -q verify` — green, 115 tests (the 2 new ones included).

## Operational use

Once this merges and deploys, prod cleanup of any other stale `OVERFLOW` rows can be done per calendar via the API instead of SQL:

```bash
curl -X POST "$API/api/v1/miot-calendar/slots/generate" \
  -H 'content-type: application/json' \
  -d '{"calendarId":"<id>","startDate":"'"$(date +%F)"'","endDate":"'"$(date -v+90d +%F)"'","reprocess":true}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `reprocess` parameter to slot generation endpoint. When enabled, unbooked slots are deleted and regenerated using current configuration, including conversion of legacy overflow slots.

* **Documentation**
  * Enhanced API documentation to clarify slot generation behavior and reprocess option.

* **Chores**
  * Version bumped to 0.5.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/miot-calendar/pull/30)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->