### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microboxlabs</groupId>
     <artifactId>miot-calendar</artifactId>
-    <version>0.5.1</version>
+    <version>0.6.0</version>
     <packaging>jar</packaging>
 
     <name>MIOT Calendar</name>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ quarkus.hibernate-orm.mapping.format.global=ignore
 
 # OpenAPI / Swagger
 quarkus.smallrye-openapi.info-title=MIOT Calendar API
-quarkus.smallrye-openapi.info-version=0.5.1
+quarkus.smallrye-openapi.info-version=0.6.0
 quarkus.smallrye-openapi.info-description=Calendar booking microservice for resource scheduling. Provides calendar management, time window configuration, slot generation, and booking operations.
 quarkus.smallrye-openapi.info-contact-name=MicroBoxLabs
 quarkus.smallrye-openapi.info-contact-url=https://microboxlabs.com


### PR DESCRIPTION
## Summary
- Bump `miot-calendar` to `0.6.0` to surface the new `POST /bookings/{id}/move` endpoint + `MoveBookingRequest` DTO landed in #32.
- Updates both `pom.xml` and `quarkus.smallrye-openapi.info-version` so the published artifact and the OpenAPI spec agree.

## Why

Additive DTO surface (no breaking change to existing endpoints) → minor bump per the same convention as the 0.4.0 → 0.5.0 capacity release. The bump didn't land in the original PR; opening this separately so the GitHub Packages deploy gets a new version on its next run.

Related: #31, #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
