### PR TITLE
feat(bookings): lifecycle status + PATCH by resource id (CALSYNC C1/C2)

### DIFF
--- a/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -83,12 +84,12 @@ public class Booking extends PanacheEntityBase {
     @PrePersist
     public void prePersist() {
         if (createdAt == null) {
-            createdAt = ZonedDateTime.now();
+            createdAt = ZonedDateTime.now(ZoneOffset.UTC);
         }
         if (status == null) {
             status = BookingStatus.PLANNED;
         }
-        updatedAt = ZonedDateTime.now();
+        updatedAt = ZonedDateTime.now(ZoneOffset.UTC);
         
         // Denormalize slot data
         if (slot != null) {
@@ -100,7 +101,7 @@ public class Booking extends PanacheEntityBase {
 
     @PreUpdate
     public void preUpdate() {
-        updatedAt = ZonedDateTime.now();
+        updatedAt = ZonedDateTime.now(ZoneOffset.UTC);
     }
 
     // Finder methods

--- a/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
@@ -114,6 +114,15 @@ public class Booking extends PanacheEntityBase {
     }
 
     /**
+     * Find bookings by calendar, date range and lifecycle status
+     */
+    public static List<Booking> findByCalendarDateRangeAndStatus(
+            UUID calendarId, LocalDate startDate, LocalDate endDate, BookingStatus status) {
+        return list("calendar.id = ?1 and slotDate >= ?2 and slotDate <= ?3 and status = ?4 order by slotDate, slotHour, slotMinutes",
+                calendarId, startDate, endDate, status);
+    }
+
+    /**
      * Find bookings by date range (all calendars)
      */
     public static List<Booking> findByDateRange(LocalDate startDate, LocalDate endDate) {
@@ -122,10 +131,26 @@ public class Booking extends PanacheEntityBase {
     }
 
     /**
+     * Find bookings by date range and lifecycle status (all calendars)
+     */
+    public static List<Booking> findByDateRangeAndStatus(
+            LocalDate startDate, LocalDate endDate, BookingStatus status) {
+        return list("slotDate >= ?1 and slotDate <= ?2 and status = ?3 order by slotDate, slotHour, slotMinutes",
+                startDate, endDate, status);
+    }
+
+    /**
      * Find booking by resource ID
      */
     public static List<Booking> findByResourceId(String resourceId) {
         return list("resourceId", resourceId);
+    }
+
+    /**
+     * Find bookings by resource ID scoped to one calendar
+     */
+    public static List<Booking> findByResourceIdAndCalendar(String resourceId, UUID calendarId) {
+        return list("resourceId = ?1 and calendar.id = ?2", resourceId, calendarId);
     }
 
     /**

--- a/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
@@ -1,5 +1,6 @@
 package com.microboxlabs.miot.calendar.entity;
 
+import com.microboxlabs.miot.calendar.model.BookingStatus;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.persistence.*;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -64,6 +65,11 @@ public class Booking extends PanacheEntityBase {
     @Column(name = "resource_data", columnDefinition = "jsonb")
     public Map<String, Object> resourceData;
 
+    // Lifecycle status, advanced forward by the workflow coordinator (CALSYNC)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    public BookingStatus status = BookingStatus.PLANNED;
+
     // Audit fields
     @Column(name = "created_at", nullable = false)
     public ZonedDateTime createdAt;
@@ -78,6 +84,9 @@ public class Booking extends PanacheEntityBase {
     public void prePersist() {
         if (createdAt == null) {
             createdAt = ZonedDateTime.now();
+        }
+        if (status == null) {
+            status = BookingStatus.PLANNED;
         }
         updatedAt = ZonedDateTime.now();
         

--- a/src/main/java/com/microboxlabs/miot/calendar/model/BookingRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/BookingRequest.java
@@ -16,8 +16,16 @@ public record BookingRequest(
     ResourceData resource,
 
     @Schema(required = true, description = "Slot date and time to book")
-    SlotData slot
+    SlotData slot,
+
+    @Schema(description = "Initial lifecycle status (defaults to PLANNED)", examples = {"PLANNED"})
+    String status
 ) {
+    /** Back-compat canonical shape without a status (defaults to PLANNED). */
+    public BookingRequest(UUID calendarId, ResourceData resource, SlotData slot) {
+        this(calendarId, resource, slot, null);
+    }
+
     /**
      * Validate the booking request
      */
@@ -33,5 +41,7 @@ public record BookingRequest(
         }
         resource.validate();
         slot.validate();
+        // Throws with the allowed values when the status is unknown
+        BookingStatus.parse(status);
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/BookingResourcePatchRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/BookingResourcePatchRequest.java
@@ -1,0 +1,37 @@
+package com.microboxlabs.miot.calendar.model;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.util.Map;
+
+/**
+ * Request to patch every booking of a resource by the resource's external id
+ * (CALSYNC C2). This is the coordinator-facing mutation: the workflow knows
+ * the service code, not the booking UUID, so it addresses bookings by
+ * {@code resourceId} (optionally scoped to one calendar).
+ *
+ * <p>{@code resourceData} is shallow-merged: top-level keys overwrite the
+ * stored payload, absent keys are preserved. {@code status} follows the same
+ * forward-only rules as the UUID-keyed update.
+ */
+@Schema(description = "Patch applied to all bookings of a resource: shallow-merged resource data and/or a lifecycle status")
+public record BookingResourcePatchRequest(
+    @Schema(description = "Top-level keys to merge into resource.data (omit to leave the payload unchanged)")
+    Map<String, Object> resourceData,
+
+    @Schema(description = "Target lifecycle status (omit to leave unchanged; regressions are rejected)", examples = {"FINISHED"})
+    String status
+) {
+    /**
+     * Validate the patch request
+     */
+    public void validate() {
+        boolean hasData = resourceData != null && !resourceData.isEmpty();
+        boolean hasStatus = status != null && !status.isBlank();
+        if (!hasData && !hasStatus) {
+            throw new IllegalArgumentException("At least one of resourceData or status is required");
+        }
+        // Throws with the allowed values when the status is unknown
+        BookingStatus.parse(status);
+    }
+}

--- a/src/main/java/com/microboxlabs/miot/calendar/model/BookingResponse.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/BookingResponse.java
@@ -23,11 +23,17 @@ public record BookingResponse(
     @Schema(required = true, description = "Slot date and time of the booking")
     SlotData slot,
 
+    @Schema(required = true, description = "Lifecycle status of the booking")
+    BookingStatus status,
+
     @Schema(required = true, description = "Timestamp when the booking was created", format = "date-time")
     ZonedDateTime createdAt,
 
     @Schema(description = "Identifier of the user who created the booking")
-    String createdBy
+    String createdBy,
+
+    @Schema(required = true, description = "Timestamp of the last change to the booking", format = "date-time")
+    ZonedDateTime updatedAt
 ) {
     /**
      * Create from entity
@@ -47,8 +53,10 @@ public record BookingResponse(
                 booking.slotHour,
                 booking.slotMinutes
             ),
+            booking.status,
             booking.createdAt,
-            booking.createdBy
+            booking.createdBy,
+            booking.updatedAt
         );
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/BookingStatus.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/BookingStatus.java
@@ -1,0 +1,65 @@
+package com.microboxlabs.miot.calendar.model;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * Lifecycle status of a booking (CALSYNC).
+ *
+ * <p>The workflow coordinator (single writer) advances a booking forward
+ * through {@code PLANNED → ASSIGNED → IN_TRANSIT → ARRIVED → FINISHED}.
+ * {@code CANCELLED} is terminal and reachable from any other status (an
+ * administrative annulment can even follow FINISHED). Regressions are
+ * rejected, with one documented exception: a re-plan that moves the booking
+ * to a different slot resets it to PLANNED (handled by the move operation,
+ * not by a status update).
+ */
+@Schema(description = "Lifecycle status of a booking, advanced by the workflow coordinator")
+public enum BookingStatus {
+    PLANNED(0),
+    ASSIGNED(1),
+    IN_TRANSIT(2),
+    ARRIVED(3),
+    FINISHED(4),
+    CANCELLED(5);
+
+    private final int rank;
+
+    BookingStatus(int rank) {
+        this.rank = rank;
+    }
+
+    /**
+     * Parse a raw status string. Returns null for null/blank (meaning "not
+     * provided"); throws IllegalArgumentException with the allowed values for
+     * anything that is not an exact status name.
+     */
+    public static BookingStatus parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return BookingStatus.valueOf(raw);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                "Unknown booking status: " + raw + " (allowed: PLANNED, ASSIGNED, IN_TRANSIT, ARRIVED, FINISHED, CANCELLED)");
+        }
+    }
+
+    /**
+     * Whether a status update from this status to {@code to} is allowed.
+     * Same-status is allowed (callers treat it as a no-op); CANCELLED is
+     * reachable from anything but leads nowhere; otherwise only forward moves.
+     */
+    public boolean canTransitionTo(BookingStatus to) {
+        if (to == this) {
+            return true;
+        }
+        if (this == CANCELLED) {
+            return false;
+        }
+        if (to == CANCELLED) {
+            return true;
+        }
+        return to.rank > this.rank;
+    }
+}

--- a/src/main/java/com/microboxlabs/miot/calendar/model/BookingUpdateRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/BookingUpdateRequest.java
@@ -3,22 +3,34 @@ package com.microboxlabs.miot.calendar.model;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
- * Request to update an existing booking's resource payload in place.
- * The slot is not changed by this operation; moving a booking to another
- * slot is done via cancel + create.
+ * Request to update an existing booking in place: its resource payload,
+ * its lifecycle status, or both. The slot is not changed by this operation;
+ * moving a booking to another slot is done via {@code POST /bookings/{id}/move}.
  */
-@Schema(description = "Request payload to update a booking's resource data in place")
+@Schema(description = "Request payload to update a booking's resource data and/or lifecycle status in place")
 public record BookingUpdateRequest(
-    @Schema(required = true, description = "Resource payload to store on the booking")
-    ResourceData resource
+    @Schema(description = "Resource payload to store on the booking (omit to leave unchanged)")
+    ResourceData resource,
+
+    @Schema(description = "Target lifecycle status (omit to leave unchanged; regressions are rejected)", examples = {"IN_TRANSIT"})
+    String status
 ) {
+    /** Back-compat canonical shape without a status. */
+    public BookingUpdateRequest(ResourceData resource) {
+        this(resource, null);
+    }
+
     /**
      * Validate the update request
      */
     public void validate() {
-        if (resource == null) {
-            throw new IllegalArgumentException("Resource is required");
+        if (resource == null && (status == null || status.isBlank())) {
+            throw new IllegalArgumentException("At least one of resource or status is required");
         }
-        resource.validate();
+        if (resource != null) {
+            resource.validate();
+        }
+        // Throws with the allowed values when the status is unknown
+        BookingStatus.parse(status);
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
@@ -104,12 +104,14 @@ public class BookingResource {
     @PUT
     @Path("/{id}")
     @Transactional
-    @Operation(operationId = "updateBooking", summary = "Update booking resource data", description = "Update an existing booking's resource payload in place. The slot is not changed; use POST /bookings/{id}/move to move a booking (or update its payload as part of a move).")
+    @Operation(operationId = "updateBooking", summary = "Update booking resource data and/or status", description = "Update an existing booking in place: its resource payload, its lifecycle status, or both. The slot is not changed; use POST /bookings/{id}/move to move a booking (or update its payload as part of a move). Status moves are forward-only; the only way back to PLANNED is a move to a different slot.")
     @APIResponse(responseCode = "200", description = "Booking updated",
         content = @Content(schema = @Schema(implementation = BookingResponse.class)))
-    @APIResponse(responseCode = "400", description = "Invalid request (e.g. missing resource or resource id mismatch)",
+    @APIResponse(responseCode = "400", description = "Invalid request (e.g. empty body, unknown status, or resource id mismatch)",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     @APIResponse(responseCode = "404", description = "Booking not found",
+        content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @APIResponse(responseCode = "409", description = "Status regression rejected",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     public Response updateBooking(
             @Parameter(description = "Unique identifier of the booking to update", required = true) @PathParam("id") UUID id,
@@ -119,7 +121,7 @@ public class BookingResource {
                 throw new IllegalArgumentException("Request body is required");
             }
             request.validate();
-            Booking booking = bookingService.updateBookingResource(id, request.resource());
+            Booking booking = bookingService.updateBookingResource(id, request.resource(), request.status());
             return Response.ok(BookingResponse.from(booking)).build();
         } catch (IllegalArgumentException e) {
             if (e.getMessage() != null && e.getMessage().startsWith("Booking not found")) {
@@ -130,6 +132,11 @@ public class BookingResource {
             LOG.warnf("Invalid booking update request: %s", e.getMessage());
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity(ErrorResponse.badRequest(e.getMessage()))
+                .build();
+        } catch (BookingValidationException e) {
+            LOG.warnf("Booking status update rejected: %s (%s)", e.getMessage(), e.getErrorCode());
+            return Response.status(Response.Status.CONFLICT)
+                .entity(ErrorResponse.conflict(e.getMessage()))
                 .build();
         }
     }

--- a/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
@@ -18,6 +18,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 
@@ -31,6 +32,8 @@ import java.util.UUID;
 public class BookingResource {
 
     private static final Logger LOG = Logger.getLogger(BookingResource.class);
+    /** Prefix of the service's not-found message, matched to map to a 404. */
+    private static final String BOOKING_NOT_FOUND = "Booking not found";
 
     @Inject
     BookingService bookingService;
@@ -45,9 +48,11 @@ public class BookingResource {
             @Parameter(description = "End date of the range (inclusive, defaults to start + 30 days)", schema = @Schema(format = "date")) @QueryParam("endDate") LocalDate endDate,
             @Parameter(description = "Filter bookings by lifecycle status") @QueryParam("status") String status) {
 
-        // Default to today if no dates provided
+        // Default to today if no dates provided. systemDefault() is explicit
+        // (Sonar S8688) while preserving the prior no-arg behavior; callers
+        // normally pass an explicit range, so this default is a convenience.
         if (startDate == null) {
-            startDate = LocalDate.now();
+            startDate = LocalDate.now(ZoneId.systemDefault());
         }
         if (endDate == null) {
             endDate = startDate.plusDays(30);
@@ -134,7 +139,7 @@ public class BookingResource {
             Booking booking = bookingService.updateBookingResource(id, request.resource(), request.status());
             return Response.ok(BookingResponse.from(booking)).build();
         } catch (IllegalArgumentException e) {
-            if (e.getMessage() != null && e.getMessage().startsWith("Booking not found")) {
+            if (e.getMessage() != null && e.getMessage().startsWith(BOOKING_NOT_FOUND)) {
                 return Response.status(Response.Status.NOT_FOUND)
                     .entity(ErrorResponse.notFound(e.getMessage()))
                     .build();
@@ -177,7 +182,7 @@ public class BookingResource {
             Booking booking = bookingService.moveBooking(id, request);
             return Response.ok(BookingResponse.from(booking)).build();
         } catch (IllegalArgumentException e) {
-            if (e.getMessage() != null && e.getMessage().startsWith("Booking not found")) {
+            if (e.getMessage() != null && e.getMessage().startsWith(BOOKING_NOT_FOUND)) {
                 return Response.status(Response.Status.NOT_FOUND)
                     .entity(ErrorResponse.notFound(e.getMessage()))
                     .build();
@@ -254,7 +259,7 @@ public class BookingResource {
                 resourceId, calendarId, request.resourceData(), request.status());
             return Response.ok(BookingListResponse.from(bookings)).build();
         } catch (IllegalArgumentException e) {
-            if (e.getMessage() != null && e.getMessage().startsWith("Booking not found")) {
+            if (e.getMessage() != null && e.getMessage().startsWith(BOOKING_NOT_FOUND)) {
                 return Response.status(Response.Status.NOT_FOUND)
                     .entity(ErrorResponse.notFound(e.getMessage()))
                     .build();

--- a/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
@@ -42,7 +42,8 @@ public class BookingResource {
     public Response listBookings(
             @Parameter(description = "Filter bookings by calendar identifier", schema = @Schema(format = "uuid")) @QueryParam("calendarId") UUID calendarId,
             @Parameter(description = "Start date of the range (inclusive, defaults to today)", schema = @Schema(format = "date")) @QueryParam("startDate") LocalDate startDate,
-            @Parameter(description = "End date of the range (inclusive, defaults to start + 30 days)", schema = @Schema(format = "date")) @QueryParam("endDate") LocalDate endDate) {
+            @Parameter(description = "End date of the range (inclusive, defaults to start + 30 days)", schema = @Schema(format = "date")) @QueryParam("endDate") LocalDate endDate,
+            @Parameter(description = "Filter bookings by lifecycle status") @QueryParam("status") String status) {
 
         // Default to today if no dates provided
         if (startDate == null) {
@@ -52,7 +53,16 @@ public class BookingResource {
             endDate = startDate.plusDays(30);
         }
 
-        List<Booking> bookings = bookingService.getBookings(calendarId, startDate, endDate);
+        BookingStatus statusFilter;
+        try {
+            statusFilter = BookingStatus.parse(status);
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(ErrorResponse.badRequest(e.getMessage()))
+                .build();
+        }
+
+        List<Booking> bookings = bookingService.getBookings(calendarId, startDate, endDate, statusFilter);
         return Response.ok(BookingListResponse.from(bookings)).build();
     }
 
@@ -212,5 +222,52 @@ public class BookingResource {
             @Parameter(description = "Identifier of the resource to get bookings for", required = true) @PathParam("resourceId") String resourceId) {
         List<Booking> bookings = bookingService.getBookingsByResourceId(resourceId);
         return Response.ok(BookingListResponse.from(bookings)).build();
+    }
+
+    @PATCH
+    @Path("/resource/{resourceId}")
+    @Transactional
+    @Operation(operationId = "patchBookingsByResource", summary = "Patch bookings by resource",
+        description = "Patch every booking of a resource, addressed by the resource's external id "
+            + "(optionally scoped to one calendar via calendarId). resourceData is shallow-merged "
+            + "(top-level keys overwrite, absent keys are preserved); status follows the same "
+            + "forward-only rules as PUT /bookings/{id}. Idempotent: re-sending the same patch "
+            + "returns 200 with the same end state.")
+    @APIResponse(responseCode = "200", description = "Patched bookings",
+        content = @Content(schema = @Schema(implementation = BookingListResponse.class)))
+    @APIResponse(responseCode = "400", description = "Invalid request (empty patch or unknown status)",
+        content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @APIResponse(responseCode = "404", description = "No booking matches the resource (and calendar scope)",
+        content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @APIResponse(responseCode = "409", description = "Status regression rejected",
+        content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    public Response patchBookingsByResource(
+            @Parameter(description = "Identifier of the resource whose bookings to patch", required = true) @PathParam("resourceId") String resourceId,
+            @Parameter(description = "Restrict the patch to bookings in this calendar", schema = @Schema(format = "uuid")) @QueryParam("calendarId") UUID calendarId,
+            BookingResourcePatchRequest request) {
+        try {
+            if (request == null) {
+                throw new IllegalArgumentException("Request body is required");
+            }
+            request.validate();
+            List<Booking> bookings = bookingService.patchBookingsByResource(
+                resourceId, calendarId, request.resourceData(), request.status());
+            return Response.ok(BookingListResponse.from(bookings)).build();
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage() != null && e.getMessage().startsWith("Booking not found")) {
+                return Response.status(Response.Status.NOT_FOUND)
+                    .entity(ErrorResponse.notFound(e.getMessage()))
+                    .build();
+            }
+            LOG.warnf("Invalid booking resource patch: %s", e.getMessage());
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(ErrorResponse.badRequest(e.getMessage()))
+                .build();
+        } catch (BookingValidationException e) {
+            LOG.warnf("Booking resource patch rejected: %s (%s)", e.getMessage(), e.getErrorCode());
+            return Response.status(Response.Status.CONFLICT)
+                .entity(ErrorResponse.conflict(e.getMessage()))
+                .build();
+        }
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
@@ -4,9 +4,11 @@ import com.microboxlabs.miot.calendar.entity.Booking;
 import com.microboxlabs.miot.calendar.entity.Calendar;
 import com.microboxlabs.miot.calendar.entity.Slot;
 import com.microboxlabs.miot.calendar.model.BookingRequest;
+import com.microboxlabs.miot.calendar.model.BookingStatus;
 import com.microboxlabs.miot.calendar.model.MoveBookingRequest;
 import com.microboxlabs.miot.calendar.model.ResourceData;
 import com.microboxlabs.miot.calendar.validation.BookingValidationService;
+import com.microboxlabs.miot.calendar.validation.BookingValidationService.BookingValidationException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -97,6 +99,8 @@ public class BookingService {
         booking.resourceType = request.resource().type();
         booking.resourceLabel = request.resource().label();
         booking.resourceData = request.resource().data();
+        BookingStatus initialStatus = BookingStatus.parse(request.status());
+        booking.status = initialStatus != null ? initialStatus : BookingStatus.PLANNED;
         booking.createdBy = createdBy;
 
         booking.persist();
@@ -166,6 +170,10 @@ public class BookingService {
             booking.slotDate = newSlot.slotDate;
             booking.slotHour = newSlot.slotHour;
             booking.slotMinutes = newSlot.slotMinutes;
+            // The documented status-regression exception: a re-plan to a new
+            // slot restarts the lifecycle. Same-slot payload refreshes keep
+            // the current status.
+            booking.status = BookingStatus.PLANNED;
         }
         if (newResource != null) {
             booking.resourceType = newResource.type();
@@ -187,33 +195,52 @@ public class BookingService {
     }
 
     /**
-     * Update an existing booking's resource payload in place.
+     * Update an existing booking in place: its resource payload, its
+     * lifecycle status, or both.
      *
-     * <p>Only {@code resourceType}, {@code resourceLabel} and {@code resourceData}
-     * change — the slot stays the same. The request's resource id must match the
-     * booking's current resource id; a booking cannot be repointed to a different
-     * resource (use cancel + create for that).
+     * <p>The slot stays the same. When a resource is given its id must match
+     * the booking's current resource id; a booking cannot be repointed to a
+     * different resource (use cancel + create for that). When a status is
+     * given it must be a forward transition (same-status is a no-op);
+     * regressions throw a {@link BookingValidationException} with code
+     * {@code STATUS_REGRESSION} — the only sanctioned way back to PLANNED is
+     * a move to a different slot (see {@link #moveBooking}).
      */
     @Transactional
-    public Booking updateBookingResource(UUID bookingId, ResourceData resource) {
+    public Booking updateBookingResource(UUID bookingId, ResourceData resource, String rawStatus) {
         Booking booking = Booking.findById(bookingId);
         if (booking == null) {
             throw new IllegalArgumentException("Booking not found: " + bookingId);
         }
 
-        resource.validate();
-        if (!resource.id().equals(booking.resourceId)) {
-            throw new IllegalArgumentException(String.format(
-                "Resource id mismatch: booking %s is for resource %s, cannot update to %s",
-                bookingId, booking.resourceId, resource.id()));
+        if (resource != null) {
+            resource.validate();
+            if (!resource.id().equals(booking.resourceId)) {
+                throw new IllegalArgumentException(String.format(
+                    "Resource id mismatch: booking %s is for resource %s, cannot update to %s",
+                    bookingId, booking.resourceId, resource.id()));
+            }
         }
 
-        booking.resourceType = resource.type();
-        booking.resourceLabel = resource.label();
-        booking.resourceData = resource.data();
+        BookingStatus targetStatus = BookingStatus.parse(rawStatus);
+        if (targetStatus != null && targetStatus != booking.status) {
+            if (!booking.status.canTransitionTo(targetStatus)) {
+                throw new BookingValidationException(String.format(
+                    "Status regression: booking %s is %s, cannot go back to %s",
+                    bookingId, booking.status, targetStatus), "STATUS_REGRESSION");
+            }
+            booking.status = targetStatus;
+        }
+
+        if (resource != null) {
+            booking.resourceType = resource.type();
+            booking.resourceLabel = resource.label();
+            booking.resourceData = resource.data();
+        }
         booking.persist();
 
-        LOG.infof("Updated booking %s resource data for resource %s", booking.id, booking.resourceId);
+        LOG.infof("Updated booking %s (resource %s, status %s)",
+            booking.id, booking.resourceId, booking.status);
 
         return booking;
     }

--- a/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
@@ -15,7 +15,9 @@ import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -34,13 +36,17 @@ public class BookingService {
     SlotService slotService;
 
     /**
-     * Get bookings by calendar and date range
+     * Get bookings by calendar, date range and (optionally) lifecycle status
      */
-    public List<Booking> getBookings(UUID calendarId, LocalDate startDate, LocalDate endDate) {
+    public List<Booking> getBookings(UUID calendarId, LocalDate startDate, LocalDate endDate, BookingStatus status) {
         if (calendarId != null) {
-            return Booking.findByCalendarAndDateRange(calendarId, startDate, endDate);
+            return status != null
+                ? Booking.findByCalendarDateRangeAndStatus(calendarId, startDate, endDate, status)
+                : Booking.findByCalendarAndDateRange(calendarId, startDate, endDate);
         }
-        return Booking.findByDateRange(startDate, endDate);
+        return status != null
+            ? Booking.findByDateRangeAndStatus(startDate, endDate, status)
+            : Booking.findByDateRange(startDate, endDate);
     }
 
     /**
@@ -243,6 +249,56 @@ public class BookingService {
             booking.id, booking.resourceId, booking.status);
 
         return booking;
+    }
+
+    /**
+     * Patch every booking of a resource, addressed by the resource's external
+     * id and optionally scoped to one calendar (CALSYNC C2).
+     *
+     * <p>{@code resourceDataPatch} is shallow-merged (top-level keys overwrite,
+     * absent keys are preserved). {@code rawStatus} follows the same
+     * forward-only transition rules as the UUID-keyed update — a regression on
+     * ANY matching booking fails the whole call so the operation stays
+     * all-or-nothing. Idempotent by construction: re-sending the same patch is
+     * a same-status no-op plus an identical merge.
+     */
+    @Transactional
+    public List<Booking> patchBookingsByResource(
+            String resourceId, UUID calendarId, Map<String, Object> resourceDataPatch, String rawStatus) {
+        List<Booking> bookings = calendarId != null
+            ? Booking.findByResourceIdAndCalendar(resourceId, calendarId)
+            : Booking.findByResourceId(resourceId);
+        if (bookings.isEmpty()) {
+            throw new IllegalArgumentException("Booking not found for resource: " + resourceId
+                + (calendarId != null ? " in calendar " + calendarId : ""));
+        }
+
+        BookingStatus targetStatus = BookingStatus.parse(rawStatus);
+        for (Booking booking : bookings) {
+            if (targetStatus != null && targetStatus != booking.status) {
+                if (!booking.status.canTransitionTo(targetStatus)) {
+                    throw new BookingValidationException(String.format(
+                        "Status regression: booking %s is %s, cannot go back to %s",
+                        booking.id, booking.status, targetStatus), "STATUS_REGRESSION");
+                }
+                booking.status = targetStatus;
+            }
+            if (resourceDataPatch != null && !resourceDataPatch.isEmpty()) {
+                Map<String, Object> merged = booking.resourceData == null
+                    ? new HashMap<>()
+                    : new HashMap<>(booking.resourceData);
+                merged.putAll(resourceDataPatch);
+                booking.resourceData = merged;
+            }
+            booking.persist();
+        }
+
+        LOG.infof("Patched %d booking(s) for resource %s (status %s, %d data key(s))",
+            bookings.size(), resourceId,
+            targetStatus != null ? targetStatus : "unchanged",
+            resourceDataPatch != null ? resourceDataPatch.size() : 0);
+
+        return bookings;
     }
 
     /**

--- a/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
@@ -275,22 +275,7 @@ public class BookingService {
 
         BookingStatus targetStatus = BookingStatus.parse(rawStatus);
         for (Booking booking : bookings) {
-            if (targetStatus != null && targetStatus != booking.status) {
-                if (!booking.status.canTransitionTo(targetStatus)) {
-                    throw new BookingValidationException(String.format(
-                        "Status regression: booking %s is %s, cannot go back to %s",
-                        booking.id, booking.status, targetStatus), "STATUS_REGRESSION");
-                }
-                booking.status = targetStatus;
-            }
-            if (resourceDataPatch != null && !resourceDataPatch.isEmpty()) {
-                Map<String, Object> merged = booking.resourceData == null
-                    ? new HashMap<>()
-                    : new HashMap<>(booking.resourceData);
-                merged.putAll(resourceDataPatch);
-                booking.resourceData = merged;
-            }
-            booking.persist();
+            applyPatch(booking, targetStatus, resourceDataPatch);
         }
 
         LOG.infof("Patched %d booking(s) for resource %s (status %s, %d data key(s))",
@@ -299,6 +284,32 @@ public class BookingService {
             resourceDataPatch != null ? resourceDataPatch.size() : 0);
 
         return bookings;
+    }
+
+    /**
+     * Apply one resource patch to a single booking: forward-only status move
+     * (regression throws {@code STATUS_REGRESSION}) and a shallow resource-data
+     * merge, then persist. Extracted from {@link #patchBookingsByResource} so
+     * the per-booking branching stays out of the loop.
+     */
+    private static void applyPatch(Booking booking, BookingStatus targetStatus,
+                                   Map<String, Object> resourceDataPatch) {
+        if (targetStatus != null && targetStatus != booking.status) {
+            if (!booking.status.canTransitionTo(targetStatus)) {
+                throw new BookingValidationException(String.format(
+                    "Status regression: booking %s is %s, cannot go back to %s",
+                    booking.id, booking.status, targetStatus), "STATUS_REGRESSION");
+            }
+            booking.status = targetStatus;
+        }
+        if (resourceDataPatch != null && !resourceDataPatch.isEmpty()) {
+            Map<String, Object> merged = booking.resourceData == null
+                ? new HashMap<>()
+                : new HashMap<>(booking.resourceData);
+            merged.putAll(resourceDataPatch);
+            booking.resourceData = merged;
+        }
+        booking.persist();
     }
 
     /**

--- a/src/main/resources/db/migration/V13__add_booking_status.sql
+++ b/src/main/resources/db/migration/V13__add_booking_status.sql
@@ -1,0 +1,9 @@
+-- CALSYNC: booking lifecycle status, advanced by the workflow coordinator.
+-- Historic rows default to PLANNED; a one-off ops backfill marks past-slot
+-- rows FINISHED (runbook lives with the ECM CALSYNC integration docs).
+ALTER TABLE cld_bookings ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'PLANNED';
+
+ALTER TABLE cld_bookings ADD CONSTRAINT chk_cld_bookings_status CHECK
+    (status IN ('PLANNED', 'ASSIGNED', 'IN_TRANSIT', 'ARRIVED', 'FINISHED', 'CANCELLED'));
+
+CREATE INDEX idx_cld_bookings_status ON cld_bookings (status);

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourcePatchTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourcePatchTest.java
@@ -1,0 +1,326 @@
+package com.microboxlabs.miot.calendar.resource;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.net.URL;
+import java.time.LocalDate;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * PATCH /bookings/resource/{resourceId} (CALSYNC C2): shallow-merge patch +
+ * status by external resource id, calendar scoping, idempotency, and the
+ * status filter on the bookings list.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BookingResourcePatchTest {
+
+    private static final String BOOKINGS = "/api/v1/miot-calendar/bookings";
+    private static final String RESOURCE_ID = "PATCH-001";
+
+    @TestHTTPResource
+    URL url;
+
+    private String calendarA;
+    private String calendarB;
+    private LocalDate slotDate;
+    private boolean setupDone = false;
+
+    @BeforeEach
+    void setupRestAssured() {
+        RestAssured.baseURI = url.toString();
+        RestAssured.port = url.getPort();
+    }
+
+    private String createCalendar(String code) {
+        return given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "code": "%s",
+                    "name": "%s",
+                    "parallelism": 2
+                }
+                """, code, code))
+            .when()
+            .post("/api/v1/miot-calendar/calendars")
+            .then()
+            .statusCode(201)
+            .extract()
+            .path("id");
+    }
+
+    private void addWindowAndSlots(String calendarId) {
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "name": "Patch Test Window",
+                    "startHour": 9,
+                    "endHour": 17,
+                    "capacity": 32,
+                    "daysOfWeek": "1,2,3,4,5,6,7",
+                    "validFrom": "%s"
+                }
+                """, LocalDate.now().toString()))
+            .when()
+            .post("/api/v1/miot-calendar/calendars/" + calendarId + "/time-windows")
+            .then()
+            .statusCode(201);
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "calendarId": "%s",
+                    "startDate": "%s",
+                    "endDate": "%s"
+                }
+                """, calendarId, slotDate, slotDate.plusDays(7)))
+            .when()
+            .post("/api/v1/miot-calendar/slots/generate")
+            .then()
+            .statusCode(200);
+    }
+
+    private void createBooking(String calendarId, String resourceId, int hour) {
+        given()
+            .contentType(ContentType.JSON)
+            .header("X-User-Id", "calsync-test")
+            .body(String.format("""
+                {
+                    "calendarId": "%s",
+                    "resource": {
+                        "id": "%s",
+                        "type": "SERVICE",
+                        "data": { "origen": "ANF", "destino": "SPC", "prioridad": 1 }
+                    },
+                    "slot": { "date": "%s", "hour": %d, "minutes": 0 }
+                }
+                """, calendarId, resourceId, slotDate, hour))
+            .when()
+            .post(BOOKINGS)
+            .then()
+            .statusCode(201);
+    }
+
+    @BeforeEach
+    void setup() {
+        if (setupDone) return;
+        setupDone = true;
+        slotDate = LocalDate.now().plusDays(1);
+
+        calendarA = createCalendar("patch-cal-a");
+        calendarB = createCalendar("patch-cal-b");
+        addWindowAndSlots(calendarA);
+        addWindowAndSlots(calendarB);
+
+        // The same resource booked in two calendars — scoping must matter.
+        createBooking(calendarA, RESOURCE_ID, 10);
+        createBooking(calendarB, RESOURCE_ID, 11);
+    }
+
+    @Test
+    @Order(1)
+    void patchStatusOnlyScopedToOneCalendar() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "status": "ASSIGNED" }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID + "?calendarId=" + calendarA)
+            .then()
+            .statusCode(200)
+            .body("data", hasSize(1))
+            .body("data[0].status", equalTo("ASSIGNED"))
+            .body("data[0].calendarId", equalTo(calendarA));
+
+        // The unscoped sibling in calendar B is untouched.
+        given()
+            .when()
+            .get(BOOKINGS + "?calendarId=" + calendarB + "&startDate=" + slotDate + "&endDate=" + slotDate)
+            .then()
+            .statusCode(200)
+            .body("data[0].status", equalTo("PLANNED"));
+    }
+
+    @Test
+    @Order(2)
+    void patchDataShallowMergePreservesExistingKeys() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "resourceData": { "assignedDriver": "Jane Doe", "prioridad": 5 } }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID + "?calendarId=" + calendarA)
+            .then()
+            .statusCode(200)
+            .body("data[0].resource.data.assignedDriver", equalTo("Jane Doe"))
+            .body("data[0].resource.data.prioridad", equalTo(5))
+            // Keys absent from the patch survive the merge.
+            .body("data[0].resource.data.origen", equalTo("ANF"))
+            .body("data[0].resource.data.destino", equalTo("SPC"));
+    }
+
+    @Test
+    @Order(3)
+    void patchStatusAndDataTogether() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "resourceData": { "eta": "2026-07-16T05:00:00Z" },
+                    "status": "IN_TRANSIT"
+                }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID + "?calendarId=" + calendarA)
+            .then()
+            .statusCode(200)
+            .body("data[0].status", equalTo("IN_TRANSIT"))
+            .body("data[0].resource.data.eta", equalTo("2026-07-16T05:00:00Z"))
+            .body("data[0].resource.data.assignedDriver", equalTo("Jane Doe"));
+    }
+
+    @Test
+    @Order(4)
+    void patchIsIdempotent() {
+        for (int i = 0; i < 2; i++) {
+            given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "resourceData": { "eta": "2026-07-16T05:00:00Z" },
+                        "status": "IN_TRANSIT"
+                    }
+                    """)
+                .when()
+                .patch(BOOKINGS + "/resource/" + RESOURCE_ID + "?calendarId=" + calendarA)
+                .then()
+                .statusCode(200)
+                .body("data[0].status", equalTo("IN_TRANSIT"));
+        }
+    }
+
+    @Test
+    @Order(5)
+    void unscopedPatchHitsEveryCalendar() {
+        // No calendarId: both bookings move forward (B: PLANNED -> IN_TRANSIT
+        // is a legal forward jump; A: same-status no-op).
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "status": "IN_TRANSIT" }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID)
+            .then()
+            .statusCode(200)
+            .body("data", hasSize(2));
+    }
+
+    @Test
+    @Order(6)
+    void regressionOnAnyMatchIs409() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "status": "ASSIGNED" }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID + "?calendarId=" + calendarA)
+            .then()
+            .statusCode(409);
+    }
+
+    @Test
+    @Order(7)
+    void emptyPatchIs400AndUnknownStatusIs400() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("{}")
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID)
+            .then()
+            .statusCode(400);
+
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "status": "DONE" }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID)
+            .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(8)
+    void unknownResourceIs404() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "status": "FINISHED" }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/NO-SUCH-RESOURCE")
+            .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(9)
+    void listFilterByStatusCombinesWithCalendarAndRange() {
+        // Move A's booking to FINISHED so the two calendars diverge.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "status": "FINISHED" }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID + "?calendarId=" + calendarA)
+            .then()
+            .statusCode(200);
+
+        given()
+            .when()
+            .get(BOOKINGS + "?calendarId=" + calendarA + "&startDate=" + slotDate
+                + "&endDate=" + slotDate + "&status=FINISHED")
+            .then()
+            .statusCode(200)
+            .body("data", hasSize(1))
+            .body("data[0].status", equalTo("FINISHED"));
+
+        given()
+            .when()
+            .get(BOOKINGS + "?calendarId=" + calendarA + "&startDate=" + slotDate
+                + "&endDate=" + slotDate + "&status=PLANNED")
+            .then()
+            .statusCode(200)
+            .body("data", hasSize(0));
+
+        // Unknown status value on the filter is a 400, not a silent empty list.
+        given()
+            .when()
+            .get(BOOKINGS + "?status=DONE")
+            .then()
+            .statusCode(400);
+    }
+}

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/BookingStatusLifecycleTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/BookingStatusLifecycleTest.java
@@ -1,0 +1,284 @@
+package com.microboxlabs.miot.calendar.resource;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.net.URL;
+import java.time.LocalDate;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+/**
+ * Booking lifecycle status (CALSYNC C1): default on create, forward-only
+ * transitions on PUT, 409 on regression, and the documented re-plan reset
+ * (move to a different slot → back to PLANNED).
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BookingStatusLifecycleTest {
+
+    private static final String BOOKINGS = "/api/v1/miot-calendar/bookings";
+
+    @TestHTTPResource
+    URL url;
+
+    private String calendarId;
+    private String bookingId;
+    private LocalDate slotDate;
+    private final int slotHour = 10;
+    private boolean setupDone = false;
+
+    @BeforeEach
+    void setupRestAssured() {
+        RestAssured.baseURI = url.toString();
+        RestAssured.port = url.getPort();
+    }
+
+    @BeforeEach
+    void setup() {
+        if (setupDone) return;
+        setupDone = true;
+        slotDate = LocalDate.now().plusDays(1);
+
+        calendarId = given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "code": "status-lifecycle-calendar",
+                    "name": "Status Lifecycle Calendar",
+                    "parallelism": 2
+                }
+                """)
+            .when()
+            .post("/api/v1/miot-calendar/calendars")
+            .then()
+            .statusCode(201)
+            .extract()
+            .path("id");
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "name": "Status Lifecycle Window",
+                    "startHour": 9,
+                    "endHour": 17,
+                    "capacity": 32,
+                    "daysOfWeek": "1,2,3,4,5,6,7",
+                    "validFrom": "%s"
+                }
+                """, LocalDate.now().toString()))
+            .when()
+            .post("/api/v1/miot-calendar/calendars/" + calendarId + "/time-windows")
+            .then()
+            .statusCode(201);
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "calendarId": "%s",
+                    "startDate": "%s",
+                    "endDate": "%s"
+                }
+                """, calendarId, slotDate, slotDate.plusDays(7)))
+            .when()
+            .post("/api/v1/miot-calendar/slots/generate")
+            .then()
+            .statusCode(200);
+    }
+
+    private String bookingBody(String resourceId, int hour, int minutes, String statusLine) {
+        return String.format("""
+            {
+                "calendarId": "%s",
+                "resource": {
+                    "id": "%s",
+                    "type": "SERVICE",
+                    "data": { "mintral_serviceCode": "%s" }
+                },
+                "slot": { "date": "%s", "hour": %d, "minutes": %d }%s
+            }
+            """, calendarId, resourceId, resourceId, slotDate, hour, minutes,
+            statusLine == null ? "" : ",\n\"status\": \"" + statusLine + "\"");
+    }
+
+    @Test
+    @Order(1)
+    void createDefaultsToPlannedAndExposesAuditFields() {
+        bookingId = given()
+            .contentType(ContentType.JSON)
+            .header("X-User-Id", "calsync-test")
+            .body(bookingBody("STS-001", slotHour, 0, null))
+            .when()
+            .post(BOOKINGS)
+            .then()
+            .statusCode(201)
+            .body("status", equalTo("PLANNED"))
+            .body("createdAt", notNullValue())
+            .body("updatedAt", notNullValue())
+            .extract()
+            .path("id");
+    }
+
+    @Test
+    @Order(2)
+    void createAcceptsExplicitStatus() {
+        given()
+            .contentType(ContentType.JSON)
+            .header("X-User-Id", "calsync-test")
+            .body(bookingBody("STS-002", slotHour, 30, "ASSIGNED"))
+            .when()
+            .post(BOOKINGS)
+            .then()
+            .statusCode(201)
+            .body("status", equalTo("ASSIGNED"));
+    }
+
+    @Test
+    @Order(3)
+    void createRejectsUnknownStatus() {
+        given()
+            .contentType(ContentType.JSON)
+            .header("X-User-Id", "calsync-test")
+            .body(bookingBody("STS-003", 11, 0, "DONE"))
+            .when()
+            .post(BOOKINGS)
+            .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(4)
+    void statusOnlyPutMovesForward() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "status": "IN_TRANSIT" }
+                """)
+            .when()
+            .put(BOOKINGS + "/" + bookingId)
+            .then()
+            .statusCode(200)
+            .body("status", equalTo("IN_TRANSIT"))
+            .body("resource.id", equalTo("STS-001"));
+    }
+
+    @Test
+    @Order(5)
+    void sameStatusPutIsANoOp() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "status": "IN_TRANSIT" }
+                """)
+            .when()
+            .put(BOOKINGS + "/" + bookingId)
+            .then()
+            .statusCode(200)
+            .body("status", equalTo("IN_TRANSIT"));
+    }
+
+    @Test
+    @Order(6)
+    void regressionIsRejectedWith409() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "status": "ASSIGNED" }
+                """)
+            .when()
+            .put(BOOKINGS + "/" + bookingId)
+            .then()
+            .statusCode(409);
+    }
+
+    @Test
+    @Order(7)
+    void emptyBodyIsRejectedWith400() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("{}")
+            .when()
+            .put(BOOKINGS + "/" + bookingId)
+            .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(8)
+    void statusAndResourceUpdateTogether() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "resource": {
+                        "id": "STS-001",
+                        "type": "SERVICE",
+                        "label": "updated label",
+                        "data": { "mintral_serviceCode": "STS-001", "assignedDriver": "Jane" }
+                    },
+                    "status": "ARRIVED"
+                }
+                """)
+            .when()
+            .put(BOOKINGS + "/" + bookingId)
+            .then()
+            .statusCode(200)
+            .body("status", equalTo("ARRIVED"))
+            .body("resource.label", equalTo("updated label"))
+            .body("resource.data.assignedDriver", equalTo("Jane"));
+    }
+
+    @Test
+    @Order(9)
+    void moveToDifferentSlotResetsStatusToPlanned() {
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                { "slot": { "date": "%s", "hour": 12, "minutes": 0 } }
+                """, slotDate))
+            .when()
+            .post(BOOKINGS + "/" + bookingId + "/move")
+            .then()
+            .statusCode(200)
+            .body("status", equalTo("PLANNED"))
+            .body("slot.hour", equalTo(12));
+    }
+
+    @Test
+    @Order(10)
+    void cancelledIsReachableFromAnywhereAndTerminal() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "status": "CANCELLED" }
+                """)
+            .when()
+            .put(BOOKINGS + "/" + bookingId)
+            .then()
+            .statusCode(200)
+            .body("status", equalTo("CANCELLED"));
+
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "status": "FINISHED" }
+                """)
+            .when()
+            .put(BOOKINGS + "/" + bookingId)
+            .then()
+            .statusCode(409);
+    }
+}


### PR DESCRIPTION
Closes #34.

## What

- **V13**: `status VARCHAR(20) NOT NULL DEFAULT 'PLANNED'` + CHECK + index on `cld_bookings`; `BookingStatus` enum with forward-only transition rules (`canTransitionTo`): same-status no-op, CANCELLED terminal-from-anywhere, regressions rejected.
- **API**: `status`/`updatedAt` on `BookingResponse`; optional `status` on `POST` (default PLANNED, 400 unknown) and `PUT /{id}` (409 `STATUS_REGRESSION` on regression); a move to a **different slot resets status to PLANNED** — the documented re-plan exception.
- **`PATCH /bookings/resource/{resourceId}?calendarId=`**: the coordinator-facing mutation (it knows the service code, not the booking UUID). Shallow-merges `resourceData` (absent keys preserved) and/or applies `status` to every matching booking, all-or-nothing on regression, 404 when nothing matches, idempotent by construction.
- **`GET /bookings`** gains an optional `status` filter (400 on unknown values).

Request records keep back-compat constructors, so existing callers compile unchanged.

## Tests

19 new (BookingStatusLifecycleTest 10, BookingResourcePatchTest 9); full suite **137/137 green**.

Part of the CALSYNC ladder (ecm-coordinator `docs/plans/calendar-workflow-sync*.md`). Deploy order: this release precedes the ecm-coordinator CALSYNC release; the one-off backfill for historic rows ships with the ECM docs (`docs/integrations/calsync-backfill-finished.sql`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)