### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microboxlabs</groupId>
     <artifactId>miot-calendar</artifactId>
-    <version>0.5.1</version>
+    <version>0.6.0</version>
     <packaging>jar</packaging>
 
     <name>MIOT Calendar</name>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ quarkus.hibernate-orm.mapping.format.global=ignore
 
 # OpenAPI / Swagger
 quarkus.smallrye-openapi.info-title=MIOT Calendar API
-quarkus.smallrye-openapi.info-version=0.5.1
+quarkus.smallrye-openapi.info-version=0.6.0
 quarkus.smallrye-openapi.info-description=Calendar booking microservice for resource scheduling. Provides calendar management, time window configuration, slot generation, and booking operations.
 quarkus.smallrye-openapi.info-contact-name=MicroBoxLabs
 quarkus.smallrye-openapi.info-contact-url=https://microboxlabs.com


### PR DESCRIPTION
## Why

The trunk deploy after PR #35 failed with **409 Conflict** re-publishing `0.5.1` to GitHub Packages — published versions are immutable, and the pom was still on `0.5.1`.

## What

- `pom.xml` `<version>` `0.5.1` → `0.6.0` (this is the value CI's deploy step reads via `mvn help:evaluate`).
- `quarkus.smallrye-openapi.info-version` bumped to match.

Merging this re-runs the trunk deploy with the fresh `0.6.0` version (the deploy step is skipped on `pull_request` events, so it only runs post-merge). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented API version from 0.5.1 to 0.6.0.
* **Chores**
  * Bumped the application release version to 0.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->