### PR TITLE
feat(booking): add an unassign op that resets ASSIGNED to PLANNED

### DIFF
--- a/src/main/java/com/microboxlabs/miot/calendar/model/BookingStatus.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/BookingStatus.java
@@ -8,10 +8,18 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
  * <p>The workflow coordinator (single writer) advances a booking forward
  * through {@code PLANNED → ASSIGNED → IN_TRANSIT → ARRIVED → FINISHED}.
  * {@code CANCELLED} is terminal and reachable from any other status (an
- * administrative annulment can even follow FINISHED). Regressions are
- * rejected, with one documented exception: a re-plan that moves the booking
- * to a different slot resets it to PLANNED (handled by the move operation,
- * not by a status update).
+ * administrative annulment can even follow FINISHED).
+ *
+ * <p>Regressions are rejected, with two documented exceptions — both carried
+ * by a dedicated <i>operation</i> rather than by a raw status update, so that
+ * a stray late patch can never walk a booking backward:
+ * <ul>
+ *   <li>a re-plan that moves the booking to a different slot resets it to
+ *       PLANNED (the move operation);</li>
+ *   <li>an unassign that drops the carrier/driver/truck while keeping the
+ *       slot resets it to PLANNED (the unassign operation, see
+ *       {@link #canUnassign()}).</li>
+ * </ul>
  */
 @Schema(description = "Lifecycle status of a booking, advanced by the workflow coordinator")
 public enum BookingStatus {
@@ -61,5 +69,26 @@ public enum BookingStatus {
             return true;
         }
         return to.rank > this.rank;
+    }
+
+    /**
+     * Whether an <b>unassign</b> may reset this booking to {@link #PLANNED} —
+     * the second sanctioned regression, alongside the re-plan move.
+     *
+     * <p>The coordinator's workflow is not monotonic: a service can go back
+     * from {@code presentDriver} to {@code assignDriver}, dropping its
+     * carrier/driver/truck while keeping its slot. That is an unassign, and it
+     * is the only reason a booking legitimately walks {@code ASSIGNED →
+     * PLANNED}.
+     *
+     * <p>Deliberately narrower than "any regression": from {@code PLANNED} it
+     * is an idempotent no-op, and from {@code ASSIGNED} it is the real reset.
+     * From {@code IN_TRANSIT} onward the truck is already moving, so a
+     * coordinator asking to unassign means the booking and the workflow have
+     * genuinely diverged — that stays a rejected {@code STATUS_REGRESSION}
+     * rather than being papered over.
+     */
+    public boolean canUnassign() {
+        return this == PLANNED || this == ASSIGNED;
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/BookingUnassignRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/BookingUnassignRequest.java
@@ -1,0 +1,38 @@
+package com.microboxlabs.miot.calendar.model;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * Request to unassign every booking of a resource: reset the lifecycle to
+ * {@link BookingStatus#PLANNED} and drop the caller's assignment keys from
+ * {@code resource.data}.
+ *
+ * <p>The caller names the keys to clear because {@code resource.data} is an
+ * opaque payload owned by the coordinator — miot-calendar knows a booking has
+ * data, not what "assigned driver" is called in it. Keeping the vocabulary on
+ * the caller's side means a new assignment field never needs a change here.
+ *
+ * <p>An empty or absent {@code clearDataKeys} is valid: it unassigns the
+ * lifecycle without touching the payload.
+ */
+@Schema(description = "Unassign bookings of a resource: reset status to PLANNED and clear the named resource.data keys")
+public record BookingUnassignRequest(
+    @Schema(description = "Top-level resource.data keys to remove (omit to leave the payload unchanged)",
+        examples = {"[\"assignedDriver\", \"assignedTruck\"]"})
+    List<String> clearDataKeys
+) {
+    /**
+     * Normalized view of {@link #clearDataKeys}: never null, no null or blank
+     * entries. A blank key would otherwise silently target nothing.
+     */
+    public List<String> safeClearDataKeys() {
+        if (clearDataKeys == null) {
+            return List.of();
+        }
+        return clearDataKeys.stream()
+            .filter(k -> k != null && !k.isBlank())
+            .toList();
+    }
+}

--- a/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
@@ -275,4 +275,48 @@ public class BookingResource {
                 .build();
         }
     }
+
+    @POST
+    @Path("/resource/{resourceId}/unassign")
+    @Transactional
+    @Operation(operationId = "unassignBookingsByResource", summary = "Unassign bookings by resource",
+        description = "Reset every booking of a resource to PLANNED and remove the named top-level keys "
+            + "from resource.data, keeping the slot. This is a sanctioned status regression for the "
+            + "coordinator's presentDriver -> assignDriver revert; a plain status patch stays "
+            + "forward-only. Allowed from PLANNED (no-op) and ASSIGNED only — from IN_TRANSIT onward "
+            + "the booking has run ahead of the workflow and the call is rejected. Idempotent: "
+            + "re-sending returns 200 with the same end state.")
+    @APIResponse(responseCode = "200", description = "Unassigned bookings",
+        content = @Content(schema = @Schema(implementation = BookingListResponse.class)))
+    @APIResponse(responseCode = "404", description = "No booking matches the resource (and calendar scope)",
+        content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @APIResponse(responseCode = "409", description = "Booking is past ASSIGNED and cannot be unassigned",
+        content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    public Response unassignBookingsByResource(
+            @Parameter(description = "Identifier of the resource whose bookings to unassign", required = true) @PathParam("resourceId") String resourceId,
+            @Parameter(description = "Restrict the unassign to bookings in this calendar", schema = @Schema(format = "uuid")) @QueryParam("calendarId") UUID calendarId,
+            BookingUnassignRequest request) {
+        try {
+            // An absent body is a valid "reset the lifecycle, touch no payload".
+            List<String> clearDataKeys = request == null ? List.of() : request.safeClearDataKeys();
+            List<Booking> bookings = bookingService.unassignBookingsByResource(
+                resourceId, calendarId, clearDataKeys);
+            return Response.ok(BookingListResponse.from(bookings)).build();
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage() != null && e.getMessage().startsWith(BOOKING_NOT_FOUND)) {
+                return Response.status(Response.Status.NOT_FOUND)
+                    .entity(ErrorResponse.notFound(e.getMessage()))
+                    .build();
+            }
+            LOG.warnf("Invalid booking unassign: %s", e.getMessage());
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(ErrorResponse.badRequest(e.getMessage()))
+                .build();
+        } catch (BookingValidationException e) {
+            LOG.warnf("Booking unassign rejected: %s (%s)", e.getMessage(), e.getErrorCode());
+            return Response.status(Response.Status.CONFLICT)
+                .entity(ErrorResponse.conflict(e.getMessage()))
+                .build();
+        }
+    }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
@@ -287,6 +287,70 @@ public class BookingService {
     }
 
     /**
+     * Unassign every booking of a resource: reset the lifecycle to
+     * {@link BookingStatus#PLANNED} and drop {@code clearDataKeys} from
+     * {@code resource.data}, keeping the slot.
+     *
+     * <p>This is the second sanctioned status regression (see
+     * {@link BookingStatus#canUnassign()}), and it exists because the
+     * coordinator's workflow is not monotonic — a service can go back from
+     * {@code presentDriver} to {@code assignDriver}. Routing it through its own
+     * operation rather than relaxing
+     * {@link BookingStatus#canTransitionTo(BookingStatus)} keeps a plain status
+     * patch strictly forward-only.
+     *
+     * <p>Clearing the keys is not optional decoration: {@code resource.data}
+     * merges are shallow and preserve absent keys, so a booking reset to
+     * PLANNED without this would still render its old driver.
+     *
+     * <p>All-or-nothing, like {@link #patchBookingsByResource}: a booking past
+     * {@code ASSIGNED} throws {@code STATUS_REGRESSION} and fails the whole
+     * call, because a coordinator unassigning an in-transit service means the
+     * two systems have genuinely diverged.
+     */
+    @Transactional
+    public List<Booking> unassignBookingsByResource(
+            String resourceId, UUID calendarId, List<String> clearDataKeys) {
+        List<Booking> bookings = calendarId != null
+            ? Booking.findByResourceIdAndCalendar(resourceId, calendarId)
+            : Booking.findByResourceId(resourceId);
+        if (bookings.isEmpty()) {
+            throw new IllegalArgumentException("Booking not found for resource: " + resourceId
+                + (calendarId != null ? " in calendar " + calendarId : ""));
+        }
+
+        for (Booking booking : bookings) {
+            applyUnassign(booking, clearDataKeys);
+        }
+
+        LOG.infof("Unassigned %d booking(s) for resource %s (cleared %d data key(s))",
+            bookings.size(), resourceId, clearDataKeys == null ? 0 : clearDataKeys.size());
+
+        return bookings;
+    }
+
+    /**
+     * Reset one booking to PLANNED and strip the named resource-data keys.
+     * Extracted from {@link #unassignBookingsByResource} to keep the
+     * per-booking branching out of the loop, mirroring {@link #applyPatch}.
+     */
+    private static void applyUnassign(Booking booking, List<String> clearDataKeys) {
+        if (!booking.status.canUnassign()) {
+            throw new BookingValidationException(String.format(
+                "Status regression: booking %s is %s, cannot be unassigned back to %s",
+                booking.id, booking.status, BookingStatus.PLANNED), "STATUS_REGRESSION");
+        }
+        booking.status = BookingStatus.PLANNED;
+
+        if (clearDataKeys != null && !clearDataKeys.isEmpty() && booking.resourceData != null) {
+            Map<String, Object> remaining = new HashMap<>(booking.resourceData);
+            clearDataKeys.forEach(remaining::remove);
+            booking.resourceData = remaining;
+        }
+        booking.persist();
+    }
+
+    /**
      * Apply one resource patch to a single booking: forward-only status move
      * (regression throws {@code STATUS_REGRESSION}) and a shallow resource-data
      * merge, then persist. Extracted from {@link #patchBookingsByResource} so

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/BookingUnassignTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/BookingUnassignTest.java
@@ -1,0 +1,304 @@
+package com.microboxlabs.miot.calendar.resource;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.net.URL;
+import java.time.LocalDate;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * POST /bookings/resource/{resourceId}/unassign: the sanctioned ASSIGNED →
+ * PLANNED regression for the coordinator's {@code presentDriver →
+ * assignDriver} revert.
+ *
+ * <p>The scenario this exists for: a service is assigned from the calendar,
+ * then the workflow is reverted. A plain status patch to PLANNED is rejected
+ * as a regression (409) and — because the executor treats 409 as benign —
+ * silently reports success while the card keeps showing the old driver.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BookingUnassignTest {
+
+    private static final String BOOKINGS = "/api/v1/miot-calendar/bookings";
+    private static final String RESOURCE_ID = "UNASSIGN-001";
+
+    @TestHTTPResource
+    URL url;
+
+    private String calendarA;
+    private String calendarB;
+    private LocalDate slotDate;
+    private boolean setupDone = false;
+
+    @BeforeEach
+    void setupRestAssured() {
+        RestAssured.baseURI = url.toString();
+        RestAssured.port = url.getPort();
+    }
+
+    @BeforeEach
+    void setup() {
+        if (setupDone) return;
+        setupDone = true;
+        slotDate = LocalDate.now().plusDays(1);
+
+        calendarA = createCalendar("unassign-cal-a");
+        calendarB = createCalendar("unassign-cal-b");
+        addWindowAndSlots(calendarA);
+        addWindowAndSlots(calendarB);
+
+        // The same resource booked in two calendars — scoping must matter.
+        createBooking(calendarA, RESOURCE_ID, 10);
+        createBooking(calendarB, RESOURCE_ID, 11);
+    }
+
+    private String createCalendar(String code) {
+        return given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "code": "%s",
+                    "name": "%s",
+                    "parallelism": 2
+                }
+                """, code, code))
+            .when()
+            .post("/api/v1/miot-calendar/calendars")
+            .then()
+            .statusCode(201)
+            .extract()
+            .path("id");
+    }
+
+    private void addWindowAndSlots(String calendarId) {
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "name": "Unassign Test Window",
+                    "startHour": 9,
+                    "endHour": 17,
+                    "capacity": 32,
+                    "daysOfWeek": "1,2,3,4,5,6,7",
+                    "validFrom": "%s"
+                }
+                """, LocalDate.now().toString()))
+            .when()
+            .post("/api/v1/miot-calendar/calendars/" + calendarId + "/time-windows")
+            .then()
+            .statusCode(201);
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "calendarId": "%s",
+                    "startDate": "%s",
+                    "endDate": "%s"
+                }
+                """, calendarId, slotDate, slotDate.plusDays(7)))
+            .when()
+            .post("/api/v1/miot-calendar/slots/generate")
+            .then()
+            .statusCode(200);
+    }
+
+    private void createBooking(String calendarId, String resourceId, int hour) {
+        given()
+            .contentType(ContentType.JSON)
+            .header("X-User-Id", "calsync-test")
+            .body(String.format("""
+                {
+                    "calendarId": "%s",
+                    "resource": {
+                        "id": "%s",
+                        "type": "SERVICE",
+                        "data": { "origen": "ANF", "destino": "SPC" }
+                    },
+                    "slot": { "date": "%s", "hour": %d, "minutes": 0 }
+                }
+                """, calendarId, resourceId, slotDate, hour))
+            .when()
+            .post(BOOKINGS)
+            .then()
+            .statusCode(201);
+    }
+
+    /** Drives a booking to ASSIGNED with a full driver tuple, as the coordinator does. */
+    private void assignInCalendar(String calendarId) {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "resourceData": {
+                        "assignedCarrier": "TRANSPORTES X",
+                        "assignedDriver": "Jane Doe",
+                        "assignedTruck": "AABB11"
+                    },
+                    "status": "ASSIGNED"
+                }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID + "?calendarId=" + calendarId)
+            .then()
+            .statusCode(200)
+            .body("data[0].status", equalTo("ASSIGNED"));
+    }
+
+    private static String unassignBody() {
+        return """
+            { "clearDataKeys": ["assignedCarrier", "assignedDriver", "assignedTruck"] }
+            """;
+    }
+
+    /**
+     * The reported defect, end to end: assigned from the calendar, then
+     * reverted. Status goes back to PLANNED and the driver tuple is gone —
+     * while the route keys, which nobody asked to clear, survive.
+     */
+    @Test
+    @Order(1)
+    void unassignResetsStatusAndClearsTheAssignmentTuple() {
+        assignInCalendar(calendarA);
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(unassignBody())
+            .when()
+            .post(BOOKINGS + "/resource/" + RESOURCE_ID + "/unassign?calendarId=" + calendarA)
+            .then()
+            .statusCode(200)
+            .body("data", hasSize(1))
+            .body("data[0].status", equalTo("PLANNED"))
+            .body("data[0].resource.data.assignedCarrier", nullValue())
+            .body("data[0].resource.data.assignedDriver", nullValue())
+            .body("data[0].resource.data.assignedTruck", nullValue())
+            // Untargeted keys are preserved — this clears a tuple, not a payload.
+            .body("data[0].resource.data.origen", equalTo("ANF"))
+            .body("data[0].resource.data.destino", equalTo("SPC"));
+    }
+
+    /** The slot is kept: an unassign is not an unplan. */
+    @Test
+    @Order(2)
+    void unassignKeepsTheSlot() {
+        given()
+            .when()
+            .get(BOOKINGS + "?calendarId=" + calendarA + "&startDate=" + slotDate + "&endDate=" + slotDate)
+            .then()
+            .statusCode(200)
+            .body("data[0].slot.date", equalTo(slotDate.toString()))
+            .body("data[0].slot.hour", equalTo(10));
+    }
+
+    /**
+     * A forward path arrives here too ({@code planService → assignDriver}), so
+     * unassigning an already-PLANNED booking must be a clean no-op rather than
+     * a 409 the caller has to special-case.
+     */
+    @Test
+    @Order(3)
+    void unassignIsIdempotent() {
+        for (int i = 0; i < 2; i++) {
+            given()
+                .contentType(ContentType.JSON)
+                .body(unassignBody())
+                .when()
+                .post(BOOKINGS + "/resource/" + RESOURCE_ID + "/unassign?calendarId=" + calendarA)
+                .then()
+                .statusCode(200)
+                .body("data[0].status", equalTo("PLANNED"));
+        }
+    }
+
+    /** Scoping matters: the sibling booking in calendar B is untouched. */
+    @Test
+    @Order(4)
+    void unassignIsScopedToOneCalendar() {
+        given()
+            .when()
+            .get(BOOKINGS + "?calendarId=" + calendarB + "&startDate=" + slotDate + "&endDate=" + slotDate)
+            .then()
+            .statusCode(200)
+            .body("data[0].status", equalTo("PLANNED"))
+            .body("data[0].resource.data.assignedDriver", nullValue());
+    }
+
+    /** No body at all is "reset the lifecycle, touch no payload". */
+    @Test
+    @Order(5)
+    void unassignWithoutBodyResetsStatusAndLeavesDataAlone() {
+        assignInCalendar(calendarA);
+
+        given()
+            .contentType(ContentType.JSON)
+            .when()
+            .post(BOOKINGS + "/resource/" + RESOURCE_ID + "/unassign?calendarId=" + calendarA)
+            .then()
+            .statusCode(200)
+            .body("data[0].status", equalTo("PLANNED"))
+            // Not named for clearing, so it stays — the caller owns the vocabulary.
+            .body("data[0].resource.data.assignedDriver", equalTo("Jane Doe"));
+    }
+
+    /**
+     * Past ASSIGNED the truck is already moving, so an unassign means the
+     * booking and the workflow have genuinely diverged. That is a real 409,
+     * not something to paper over.
+     */
+    @Test
+    @Order(6)
+    void unassignFromInTransitIsRejected() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "status": "IN_TRANSIT" }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID + "?calendarId=" + calendarA)
+            .then()
+            .statusCode(200);
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(unassignBody())
+            .when()
+            .post(BOOKINGS + "/resource/" + RESOURCE_ID + "/unassign?calendarId=" + calendarA)
+            .then()
+            .statusCode(409);
+
+        // Rejected all-or-nothing: the booking kept its status.
+        given()
+            .when()
+            .get(BOOKINGS + "?calendarId=" + calendarA + "&startDate=" + slotDate + "&endDate=" + slotDate)
+            .then()
+            .body("data[0].status", equalTo("IN_TRANSIT"));
+    }
+
+    @Test
+    @Order(7)
+    void unassignUnknownResourceIs404() {
+        given()
+            .contentType(ContentType.JSON)
+            .body(unassignBody())
+            .when()
+            .post(BOOKINGS + "/resource/NO-SUCH-RESOURCE/unassign")
+            .then()
+            .statusCode(404);
+    }
+}


### PR DESCRIPTION
First of three PRs for microboxlabs/ecm-coordinator#321 — this one establishes the contract the other two code against.

## Problem

Reverting a service from `presentDriver` back to `assignDriver` leaves its booking showing **ASSIGNED**, driver still on the card, while the job that should fix it reports SUCCEEDED.

The coordinator sends that revert as a plain status patch to PLANNED. `BookingStatus:63` rejects it (`to.rank > this.rank`), the API returns 409 `STATUS_REGRESSION`, and the caller swallows it as benign.

The root assumption is stated in `BookingStatus:8-9` — the coordinator is a *single writer that advances a booking forward*. That is false. `assignDriver ↔ presentDriver` is a legitimate round trip.

## Approach

Add the regression as its own **operation** rather than relaxing `canTransitionTo`.

The enum already sets this precedent: the one sanctioned reset — a re-plan — is carried by the move operation, not by a status update. Widening the rank comparison would instead let any stray late patch walk a booking backward, which is exactly what the invariant exists to prevent.

`POST /bookings/resource/{resourceId}/unassign?calendarId=`

- resets to PLANNED and **keeps the slot** (an unassign is not an unplan)
- removes caller-named top-level keys from `resource.data`

`canUnassign()` is deliberately narrow:

| from | result |
|---|---|
| PLANNED | idempotent no-op — the forward `planService → assignDriver` path lands here too |
| ASSIGNED | the real reset |
| IN_TRANSIT and beyond | **409** — the truck is moving; an unassign means the two systems have genuinely diverged |

## Why the caller names the keys

`resource.data` is an opaque coordinator-owned payload; miot-calendar knows a booking *has* data, not what "assigned driver" is called in it. Keeping the vocabulary caller-side means a new assignment field never needs a change here.

Clearing them is not decoration. Data merges are shallow and preserve absent keys (`BookingResourcePatchRequest:13-15`), so a booking reset to PLANNED *without* this would still render its old driver — the same defect, one field down.

## Tests

`BookingUnassignTest` — 7 tests covering the reported scenario end to end, slot preservation, idempotency, calendar scoping, the empty-body case, the IN_TRANSIT rejection (asserting all-or-nothing), and 404.

Full suite: **144 tests, 0 failures, 0 errors**.

## Follow-ups

- miot-integrations: `OP_UNASSIGN` + executor + client method
- ecm-coordinator: `OnCreateAssignDriverBinding` co-enqueues `ensure` + `unassign` as one chain

Also tracked in #321, independent of this change: the executor reports SUCCEEDED for a 409 on a status it *intended* to regress to. That is what hid this defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API to unassign all bookings associated with a resource, optionally limited to a calendar.
  - Unassigning can reset eligible bookings to **Planned** and clear selected resource data fields.
  - Added validation to prevent unsupported status changes and return clear error responses.

- **Bug Fixes**
  - Unassign operations preserve booking slots and unaffected resource data.
  - Repeated unassign requests are safely supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->