### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microboxlabs</groupId>
     <artifactId>miot-calendar</artifactId>
-    <version>0.6.0</version>
+    <version>0.6.1</version>
     <packaging>jar</packaging>
 
     <name>MIOT Calendar</name>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ quarkus.hibernate-orm.mapping.format.global=ignore
 
 # OpenAPI / Swagger
 quarkus.smallrye-openapi.info-title=MIOT Calendar API
-quarkus.smallrye-openapi.info-version=0.6.0
+quarkus.smallrye-openapi.info-version=0.6.1
 quarkus.smallrye-openapi.info-description=Calendar booking microservice for resource scheduling. Provides calendar management, time window configuration, slot generation, and booking operations.
 quarkus.smallrye-openapi.info-contact-name=MicroBoxLabs
 quarkus.smallrye-openapi.info-contact-url=https://microboxlabs.com


### PR DESCRIPTION
Patch bump `0.6.0` → `0.6.1` so the trunk deploy can publish the unassign operation (#37).

GitHub Packages versions are immutable, so re-publishing an existing version 409s on the deploy step. Bumps the two places the previous release touched:

- `pom.xml` project version — read by CI's deploy step via `mvn help:evaluate`
- `quarkus.smallrye-openapi.info-version` — kept in lockstep so the published spec matches the artifact

## Why patch and not minor

#37 is purely additive: a new `POST /bookings/resource/{id}/unassign` endpoint. No existing endpoint changes shape, and the forward-only rule on the status patch is untouched — the unassign carries the regression on its own operation precisely so callers of `PATCH /bookings/resource/{id}` see no behavior change.

## Note

Branched from `trunk`, independent of #37 — neither PR touches the other's files, so they can merge in either order. If #37 merges first this still applies cleanly.

Left `pom.xml:268` alone: that `<version>0.6.0</version>` is the `central-publishing-maven-plugin`'s own version, coincidentally the same string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)