### PR TITLE
feat(bookings): external sync-status dimension (PENDING/CONFIRMED/REJECTED)

### DIFF
--- a/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
@@ -1,6 +1,7 @@
 package com.microboxlabs.miot.calendar.entity;
 
 import com.microboxlabs.miot.calendar.model.BookingStatus;
+import com.microboxlabs.miot.calendar.model.BookingSyncStatus;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.persistence.*;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -70,6 +71,21 @@ public class Booking extends PanacheEntityBase {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
     public BookingStatus status = BookingStatus.PLANNED;
+
+    // Synchronization state of the booking's current data with an external
+    // downstream system — orthogonal to the lifecycle status; null =
+    // untracked. Written by the integration layer that mirrors bookings
+    // outward (PENDING when a sync is dispatched, CONFIRMED/REJECTED once
+    // the external system acknowledges).
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sync_status", length = 20)
+    public BookingSyncStatus syncStatus;
+
+    @Column(name = "sync_detail", length = 500)
+    public String syncDetail;
+
+    @Column(name = "sync_at")
+    public ZonedDateTime syncAt;
 
     // Audit fields
     @Column(name = "created_at", nullable = false)

--- a/src/main/java/com/microboxlabs/miot/calendar/model/BookingResourcePatchRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/BookingResourcePatchRequest.java
@@ -12,15 +12,24 @@ import java.util.Map;
  *
  * <p>{@code resourceData} is shallow-merged: top-level keys overwrite the
  * stored payload, absent keys are preserved. {@code status} follows the same
- * forward-only rules as the UUID-keyed update.
+ * forward-only rules as the UUID-keyed update. {@code syncStatus} is the
+ * orthogonal external-sync dimension: no transition rules (the integration
+ * layer that mirrors bookings outward is the single writer and owns the
+ * sequencing), and setting it stamps {@code syncAt}.
  */
-@Schema(description = "Patch applied to all bookings of a resource: shallow-merged resource data and/or a lifecycle status")
+@Schema(description = "Patch applied to all bookings of a resource: shallow-merged resource data, a lifecycle status and/or an external-sync status")
 public record BookingResourcePatchRequest(
     @Schema(description = "Top-level keys to merge into resource.data (omit to leave the payload unchanged)")
     Map<String, Object> resourceData,
 
     @Schema(description = "Target lifecycle status (omit to leave unchanged; regressions are rejected)", examples = {"FINISHED"})
-    String status
+    String status,
+
+    @Schema(description = "External-system acknowledgement of the booking's current data (omit to leave unchanged)", examples = {"CONFIRMED"})
+    String syncStatus,
+
+    @Schema(description = "External-system acknowledgement/rejection detail, stored alongside syncStatus")
+    String syncDetail
 ) {
     /**
      * Validate the patch request
@@ -28,10 +37,13 @@ public record BookingResourcePatchRequest(
     public void validate() {
         boolean hasData = resourceData != null && !resourceData.isEmpty();
         boolean hasStatus = status != null && !status.isBlank();
-        if (!hasData && !hasStatus) {
-            throw new IllegalArgumentException("At least one of resourceData or status is required");
+        boolean hasSyncStatus = syncStatus != null && !syncStatus.isBlank();
+        if (!hasData && !hasStatus && !hasSyncStatus) {
+            throw new IllegalArgumentException(
+                "At least one of resourceData, status or syncStatus is required");
         }
-        // Throws with the allowed values when the status is unknown
+        // Throw with the allowed values when either status is unknown
         BookingStatus.parse(status);
+        BookingSyncStatus.parse(syncStatus);
     }
 }

--- a/src/main/java/com/microboxlabs/miot/calendar/model/BookingResponse.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/BookingResponse.java
@@ -26,6 +26,15 @@ public record BookingResponse(
     @Schema(required = true, description = "Lifecycle status of the booking")
     BookingStatus status,
 
+    @Schema(description = "External-system acknowledgement of the booking's current data (null = untracked)")
+    BookingSyncStatus syncStatus,
+
+    @Schema(description = "External-system acknowledgement/rejection detail")
+    String syncDetail,
+
+    @Schema(description = "Timestamp of the last syncStatus transition", format = "date-time")
+    ZonedDateTime syncAt,
+
     @Schema(required = true, description = "Timestamp when the booking was created", format = "date-time")
     ZonedDateTime createdAt,
 
@@ -54,6 +63,9 @@ public record BookingResponse(
                 booking.slotMinutes
             ),
             booking.status,
+            booking.syncStatus,
+            booking.syncDetail,
+            booking.syncAt,
             booking.createdAt,
             booking.createdBy,
             booking.updatedAt

--- a/src/main/java/com/microboxlabs/miot/calendar/model/BookingSyncStatus.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/BookingSyncStatus.java
@@ -1,0 +1,41 @@
+package com.microboxlabs.miot.calendar.model;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * Acknowledgement state of the booking's <b>current</b> data by an external
+ * downstream system that mirrors this calendar. Orthogonal to the monotonic
+ * lifecycle {@link BookingStatus}: a booking can be ASSIGNED yet unconfirmed
+ * downstream, and a data change legitimately drops back to PENDING, which the
+ * forward-only status ladder cannot express. There are deliberately no
+ * transition rules here — the integration layer that projects bookings
+ * outward is the single writer and owns the sequencing.
+ *
+ * <p>Null (column absent) = untracked: calendars with no external mirror, or
+ * bookings created before the feature.
+ */
+@Schema(description = "External-system acknowledgement of the booking's current data")
+public enum BookingSyncStatus {
+    /** A synchronization is queued or in flight; not acknowledged yet. */
+    PENDING,
+    /** The external system acknowledged the booking's current data. */
+    CONFIRMED,
+    /** The external system refused it; see {@code syncDetail} for the reason. */
+    REJECTED;
+
+    /**
+     * Parse a raw value. Returns null for null/blank (meaning "not provided");
+     * throws IllegalArgumentException with the allowed values otherwise.
+     */
+    public static BookingSyncStatus parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return BookingSyncStatus.valueOf(raw);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                "Unknown booking sync status: " + raw + " (allowed: PENDING, CONFIRMED, REJECTED)");
+        }
+    }
+}

--- a/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
@@ -256,7 +256,8 @@ public class BookingResource {
             }
             request.validate();
             List<Booking> bookings = bookingService.patchBookingsByResource(
-                resourceId, calendarId, request.resourceData(), request.status());
+                resourceId, calendarId, request.resourceData(), request.status(),
+                request.syncStatus(), request.syncDetail());
             return Response.ok(BookingListResponse.from(bookings)).build();
         } catch (IllegalArgumentException e) {
             if (e.getMessage() != null && e.getMessage().startsWith(BOOKING_NOT_FOUND)) {

--- a/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
@@ -5,6 +5,7 @@ import com.microboxlabs.miot.calendar.entity.Calendar;
 import com.microboxlabs.miot.calendar.entity.Slot;
 import com.microboxlabs.miot.calendar.model.BookingRequest;
 import com.microboxlabs.miot.calendar.model.BookingStatus;
+import com.microboxlabs.miot.calendar.model.BookingSyncStatus;
 import com.microboxlabs.miot.calendar.model.MoveBookingRequest;
 import com.microboxlabs.miot.calendar.model.ResourceData;
 import com.microboxlabs.miot.calendar.validation.BookingValidationService;
@@ -15,6 +16,8 @@ import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -265,6 +268,20 @@ public class BookingService {
     @Transactional
     public List<Booking> patchBookingsByResource(
             String resourceId, UUID calendarId, Map<String, Object> resourceDataPatch, String rawStatus) {
+        return patchBookingsByResource(resourceId, calendarId, resourceDataPatch, rawStatus, null, null);
+    }
+
+    /**
+     * Variant carrying the external-sync patch: {@code rawSyncStatus}
+     * (PENDING/CONFIRMED/REJECTED) plus its optional detail. No transition
+     * rules — the integration layer that mirrors bookings outward is the
+     * single writer and owns the sequencing; setting it stamps
+     * {@code syncAt}.
+     */
+    @Transactional
+    public List<Booking> patchBookingsByResource(
+            String resourceId, UUID calendarId, Map<String, Object> resourceDataPatch, String rawStatus,
+            String rawSyncStatus, String syncDetail) {
         List<Booking> bookings = calendarId != null
             ? Booking.findByResourceIdAndCalendar(resourceId, calendarId)
             : Booking.findByResourceId(resourceId);
@@ -274,13 +291,15 @@ public class BookingService {
         }
 
         BookingStatus targetStatus = BookingStatus.parse(rawStatus);
+        BookingSyncStatus targetSyncStatus = BookingSyncStatus.parse(rawSyncStatus);
         for (Booking booking : bookings) {
-            applyPatch(booking, targetStatus, resourceDataPatch);
+            applyPatch(booking, targetStatus, resourceDataPatch, targetSyncStatus, syncDetail);
         }
 
-        LOG.infof("Patched %d booking(s) for resource %s (status %s, %d data key(s))",
+        LOG.infof("Patched %d booking(s) for resource %s (status %s, syncStatus %s, %d data key(s))",
             bookings.size(), resourceId,
             targetStatus != null ? targetStatus : "unchanged",
+            targetSyncStatus != null ? targetSyncStatus : "unchanged",
             resourceDataPatch != null ? resourceDataPatch.size() : 0);
 
         return bookings;
@@ -352,12 +371,14 @@ public class BookingService {
 
     /**
      * Apply one resource patch to a single booking: forward-only status move
-     * (regression throws {@code STATUS_REGRESSION}) and a shallow resource-data
-     * merge, then persist. Extracted from {@link #patchBookingsByResource} so
-     * the per-booking branching stays out of the loop.
+     * (regression throws {@code STATUS_REGRESSION}), a shallow resource-data
+     * merge and the free-form external-sync stamp, then persist. Extracted from
+     * {@link #patchBookingsByResource} so the per-booking branching stays out
+     * of the loop.
      */
     private static void applyPatch(Booking booking, BookingStatus targetStatus,
-                                   Map<String, Object> resourceDataPatch) {
+                                   Map<String, Object> resourceDataPatch,
+                                   BookingSyncStatus targetSyncStatus, String syncDetail) {
         if (targetStatus != null && targetStatus != booking.status) {
             if (!booking.status.canTransitionTo(targetStatus)) {
                 throw new BookingValidationException(String.format(
@@ -372,6 +393,11 @@ public class BookingService {
                 : new HashMap<>(booking.resourceData);
             merged.putAll(resourceDataPatch);
             booking.resourceData = merged;
+        }
+        if (targetSyncStatus != null) {
+            booking.syncStatus = targetSyncStatus;
+            booking.syncDetail = syncDetail;
+            booking.syncAt = ZonedDateTime.now(ZoneOffset.UTC);
         }
         booking.persist();
     }

--- a/src/main/resources/db/migration/V14__add_booking_sync_status.sql
+++ b/src/main/resources/db/migration/V14__add_booking_sync_status.sql
@@ -1,0 +1,25 @@
+-- Acknowledgement state of a booking's current data by an external
+-- downstream system that mirrors this calendar — orthogonal to the
+-- monotonic lifecycle `status` (a booking can be ASSIGNED yet unconfirmed
+-- downstream, and a data change legitimately drops back to PENDING, which
+-- the forward-only status ladder cannot express).
+--
+-- NULL = untracked (calendars with no external mirror, or rows created
+-- before this feature).
+-- PENDING   = a synchronization is queued/in flight; not acknowledged yet.
+-- CONFIRMED = the external system acknowledged the booking's current data.
+-- REJECTED  = the external system refused it; see sync_detail.
+
+ALTER TABLE cld_bookings ADD COLUMN sync_status VARCHAR(20);
+ALTER TABLE cld_bookings ADD COLUMN sync_detail VARCHAR(500);
+ALTER TABLE cld_bookings ADD COLUMN sync_at TIMESTAMPTZ;
+
+ALTER TABLE cld_bookings ADD CONSTRAINT chk_cld_bookings_sync_status CHECK
+    (sync_status IS NULL OR sync_status IN ('PENDING', 'CONFIRMED', 'REJECTED'));
+
+COMMENT ON COLUMN cld_bookings.sync_status IS
+    'External-system acknowledgement of the booking''s current data: PENDING/CONFIRMED/REJECTED; NULL = untracked';
+COMMENT ON COLUMN cld_bookings.sync_detail IS
+    'External-system acknowledgement/rejection detail';
+COMMENT ON COLUMN cld_bookings.sync_at IS
+    'Timestamp of the last sync_status transition';

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourcePatchTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourcePatchTest.java
@@ -323,4 +323,76 @@ class BookingResourcePatchTest {
             .then()
             .statusCode(400);
     }
+
+    @Test
+    @Order(10)
+    void syncStatusPatchStampsDetailAndTimestampWithoutTouchingLifecycle() {
+        // A syncStatus-only patch is a valid body (no status/resourceData needed).
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "syncStatus": "PENDING" }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID + "?calendarId=" + calendarA)
+            .then()
+            .statusCode(200)
+            .body("data[0].syncStatus", equalTo("PENDING"))
+            .body("data[0].syncAt", org.hamcrest.CoreMatchers.notNullValue())
+            // The lifecycle status is untouched (FINISHED from the previous test).
+            .body("data[0].status", equalTo("FINISHED"));
+
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "syncStatus": "CONFIRMED", "syncDetail": "Accepted by external system" }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID + "?calendarId=" + calendarA)
+            .then()
+            .statusCode(200)
+            .body("data[0].syncStatus", equalTo("CONFIRMED"))
+            .body("data[0].syncDetail", equalTo("Accepted by external system"));
+    }
+
+    @Test
+    @Order(11)
+    void syncStatusHasNoForwardOnlyRule() {
+        // A re-assignment legitimately reopens the confirmation window:
+        // CONFIRMED -> PENDING must NOT be rejected as a regression.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "syncStatus": "PENDING" }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID + "?calendarId=" + calendarA)
+            .then()
+            .statusCode(200)
+            .body("data[0].syncStatus", equalTo("PENDING"))
+            // The previous detail does not survive the transition.
+            .body("data[0].syncDetail", nullValue());
+    }
+
+    @Test
+    @Order(12)
+    void unknownSyncStatusIs400AndUntouchedBookingsReadNull() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                { "syncStatus": "MAYBE" }
+                """)
+            .when()
+            .patch(BOOKINGS + "/resource/" + RESOURCE_ID)
+            .then()
+            .statusCode(400);
+
+        // The calendar-B sibling has never been sync-patched: null = untracked.
+        given()
+            .when()
+            .get(BOOKINGS + "?calendarId=" + calendarB + "&startDate=" + slotDate + "&endDate=" + slotDate)
+            .then()
+            .statusCode(200)
+            .body("data[0].syncStatus", nullValue());
+    }
 }


### PR DESCRIPTION
Replaces #39 (same functionality, generic documentation).

## What

Bookings often mirror into external downstream systems, and a booking's lifecycle `status` can't express whether that system has acknowledged the booking's current data — a booking can be `ASSIGNED` here while the external mirror has refused it, or not confirmed it yet, and a data change legitimately reopens the question. This adds the **external synchronization state** as its own dimension, orthogonal to the lifecycle status:

- **V14 migration**: `cld_bookings.sync_status` (`PENDING` | `CONFIRMED` | `REJECTED`, CHECK-constrained, nullable — null = untracked), `sync_detail` (free-form acknowledgement/rejection detail), `sync_at` (last transition).
- **`BookingSyncStatus`** enum with `parse()` mirroring `BookingStatus.parse()` semantics.
- **Resource-patch API** (`PATCH /bookings/resource/{resourceId}`): accepts `syncStatus` + `syncDetail` (alone or alongside `status`/`resourceData`); setting it stamps `sync_at`. Unknown values are a 400.
- **`BookingResponse`** exposes the three fields.

## Why no forward-only rule

Unlike the lifecycle ladder, `sync_status` has **no transition rules**: a data change legitimately reopens `PENDING` after `CONFIRMED`. The integration layer that projects bookings outward is the single writer and owns the sequencing — this service only records the state it is told.

## Tests

Full suite 147/147, including 3 new cases in `BookingResourcePatchTest`: a syncStatus-only patch is valid and stamps `syncAt` without touching the lifecycle status; `CONFIRMED → PENDING` is not a regression; unknown value is 400 and untouched bookings read null.

## Rollout

Columns are nullable and the API is additive — safe to deploy independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
