### PR TITLE
chore: bump version to 0.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microboxlabs</groupId>
     <artifactId>miot-calendar</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2</version>
     <packaging>jar</packaging>
 
     <name>MIOT Calendar</name>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ quarkus.hibernate-orm.mapping.format.global=ignore
 
 # OpenAPI / Swagger
 quarkus.smallrye-openapi.info-title=MIOT Calendar API
-quarkus.smallrye-openapi.info-version=0.6.1
+quarkus.smallrye-openapi.info-version=0.6.2
 quarkus.smallrye-openapi.info-description=Calendar booking microservice for resource scheduling. Provides calendar management, time window configuration, slot generation, and booking operations.
 quarkus.smallrye-openapi.info-contact-name=MicroBoxLabs
 quarkus.smallrye-openapi.info-contact-url=https://microboxlabs.com


### PR DESCRIPTION
Patch release after #40 (external sync-status dimension on bookings: V14 migration, `syncStatus`/`syncDetail` on the resource-patch API and `BookingResponse`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)