### PR TITLE
chore: bump version to 0.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microboxlabs</groupId>
     <artifactId>miot-calendar</artifactId>
-    <version>0.6.2</version>
+    <version>0.6.3</version>
     <packaging>jar</packaging>
 
     <name>MIOT Calendar</name>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ quarkus.hibernate-orm.mapping.format.global=ignore
 
 # OpenAPI / Swagger
 quarkus.smallrye-openapi.info-title=MIOT Calendar API
-quarkus.smallrye-openapi.info-version=0.6.2
+quarkus.smallrye-openapi.info-version=0.6.3
 quarkus.smallrye-openapi.info-description=Calendar booking microservice for resource scheduling. Provides calendar management, time window configuration, slot generation, and booking operations.
 quarkus.smallrye-openapi.info-contact-name=MicroBoxLabs
 quarkus.smallrye-openapi.info-contact-url=https://microboxlabs.com


### PR DESCRIPTION
Patch bump `0.6.2 → 0.6.3`, releasing the default-calendar feature now that #42 is merged to trunk.

Touches the two files the repo's bump convention uses:
- `pom.xml` `<version>`
- `application.properties` `quarkus.smallrye-openapi.info-version`

What 0.6.3 contains (all merged): the `isDefault` flag on a calendar, `GET /calendars/default?origin=X` (204 when none), the demote-previous-holder rule, and the `V15__add_calendar_default.sql` migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)