### PR TITLE
[bookings] Add resource identifier search

### DIFF
--- a/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
@@ -10,7 +10,10 @@ import org.hibernate.type.SqlTypes;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -121,6 +124,54 @@ public class Booking extends PanacheEntityBase {
     }
 
     // Finder methods
+
+    /**
+     * Find bookings whose generic resource identifier contains the requested
+     * text, optionally narrowed by the other list filters.
+     *
+     * <p>{@code resourceIdContains} is deliberately expressed in calendar-domain
+     * language. Callers decide what their resource identifiers mean.
+     */
+    public static List<Booking> findByResourceIdContaining(
+            UUID calendarId,
+            LocalDate startDate,
+            LocalDate endDate,
+            BookingStatus status,
+            String resourceIdContains) {
+        var conditions = new ArrayList<String>();
+        conditions.add("lower(resourceId) like :resourceIdPattern escape '!'");
+        var parameters = new HashMap<String, Object>();
+        parameters.put(
+            "resourceIdPattern",
+            "%" + escapeLikePattern(resourceIdContains.trim().toLowerCase(Locale.ROOT)) + "%");
+
+        if (calendarId != null) {
+            conditions.add("calendar.id = :calendarId");
+            parameters.put("calendarId", calendarId);
+        }
+        if (startDate != null) {
+            conditions.add("slotDate >= :startDate");
+            parameters.put("startDate", startDate);
+        }
+        if (endDate != null) {
+            conditions.add("slotDate <= :endDate");
+            parameters.put("endDate", endDate);
+        }
+        if (status != null) {
+            conditions.add("status = :status");
+            parameters.put("status", status);
+        }
+        String predicates = String.join(" and ", conditions);
+        return find(
+            predicates + " order by slotDate, slotHour, slotMinutes", parameters).list();
+    }
+
+    private static String escapeLikePattern(String value) {
+        return value
+            .replace("!", "!!")
+            .replace("%", "!%")
+            .replace("_", "!_");
+    }
 
     /**
      * Find bookings by calendar and date range

--- a/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/entity/Booking.java
@@ -32,6 +32,8 @@ import java.util.UUID;
 })
 public class Booking extends PanacheEntityBase {
 
+    static final int RESOURCE_SEARCH_MAX_RESULTS = 100;
+
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "id")
@@ -163,7 +165,9 @@ public class Booking extends PanacheEntityBase {
         }
         String predicates = String.join(" and ", conditions);
         return find(
-            predicates + " order by slotDate, slotHour, slotMinutes", parameters).list();
+            predicates + " order by slotDate, slotHour, slotMinutes", parameters)
+            .range(0, RESOURCE_SEARCH_MAX_RESULTS - 1)
+            .list();
     }
 
     private static String escapeLikePattern(String value) {

--- a/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
@@ -44,10 +44,10 @@ public class BookingResource {
         content = @Content(schema = @Schema(implementation = BookingListResponse.class)))
     public Response listBookings(
             @Parameter(description = "Filter bookings by calendar identifier", schema = @Schema(format = "uuid")) @QueryParam("calendarId") UUID calendarId,
-            @Parameter(description = "Start date of the range (inclusive, defaults to today)", schema = @Schema(format = "date")) @QueryParam("startDate") LocalDate startDate,
-            @Parameter(description = "End date of the range (inclusive, defaults to start + 30 days)", schema = @Schema(format = "date")) @QueryParam("endDate") LocalDate endDate,
+            @Parameter(description = "Start date of the range (inclusive; defaults to today when resourceIdContains is absent)", schema = @Schema(format = "date")) @QueryParam("startDate") LocalDate startDate,
+            @Parameter(description = "End date of the range (inclusive; defaults to start + 30 days when startDate is supplied, and remains unbounded for date-less resource searches)", schema = @Schema(format = "date")) @QueryParam("endDate") LocalDate endDate,
             @Parameter(description = "Filter bookings by lifecycle status") @QueryParam("status") String status,
-            @Parameter(description = "Case-insensitive substring to match against the generic resource identifier") @QueryParam("resourceIdContains") String resourceIdContains) {
+            @Parameter(description = "Case-insensitive substring to match against the generic resource identifier; returns at most 100 bookings") @QueryParam("resourceIdContains") String resourceIdContains) {
 
         boolean resourceSearch = resourceIdContains != null && !resourceIdContains.isBlank();
         if (resourceSearch) {

--- a/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/resource/BookingResource.java
@@ -39,23 +39,31 @@ public class BookingResource {
     BookingService bookingService;
 
     @GET
-    @Operation(operationId = "listBookings", summary = "List bookings", description = "Retrieve bookings filtered by calendar and date range. Defaults to the next 30 days if no dates are provided.")
+    @Operation(operationId = "listBookings", summary = "List bookings", description = "Retrieve bookings filtered by calendar, date range, lifecycle status, and resource identifier. Date-less resource searches span all booking dates; other date-less searches default to the next 30 days.")
     @APIResponse(responseCode = "200", description = "List of bookings",
         content = @Content(schema = @Schema(implementation = BookingListResponse.class)))
     public Response listBookings(
             @Parameter(description = "Filter bookings by calendar identifier", schema = @Schema(format = "uuid")) @QueryParam("calendarId") UUID calendarId,
             @Parameter(description = "Start date of the range (inclusive, defaults to today)", schema = @Schema(format = "date")) @QueryParam("startDate") LocalDate startDate,
             @Parameter(description = "End date of the range (inclusive, defaults to start + 30 days)", schema = @Schema(format = "date")) @QueryParam("endDate") LocalDate endDate,
-            @Parameter(description = "Filter bookings by lifecycle status") @QueryParam("status") String status) {
+            @Parameter(description = "Filter bookings by lifecycle status") @QueryParam("status") String status,
+            @Parameter(description = "Case-insensitive substring to match against the generic resource identifier") @QueryParam("resourceIdContains") String resourceIdContains) {
 
-        // Default to today if no dates provided. systemDefault() is explicit
-        // (Sonar S8688) while preserving the prior no-arg behavior; callers
-        // normally pass an explicit range, so this default is a convenience.
-        if (startDate == null) {
-            startDate = LocalDate.now(ZoneId.systemDefault());
-        }
-        if (endDate == null) {
-            endDate = startDate.plusDays(30);
+        boolean resourceSearch = resourceIdContains != null && !resourceIdContains.isBlank();
+        if (resourceSearch) {
+            // An explicitly-started resource search keeps the established
+            // 30-day default while a date-less one intentionally spans all dates.
+            if (startDate != null && endDate == null) {
+                endDate = startDate.plusDays(30);
+            }
+        } else {
+            // Preserve the existing bounded default for unfiltered list calls.
+            if (startDate == null) {
+                startDate = LocalDate.now(ZoneId.systemDefault());
+            }
+            if (endDate == null) {
+                endDate = startDate.plusDays(30);
+            }
         }
 
         BookingStatus statusFilter;
@@ -67,7 +75,8 @@ public class BookingResource {
                 .build();
         }
 
-        List<Booking> bookings = bookingService.getBookings(calendarId, startDate, endDate, statusFilter);
+        List<Booking> bookings = bookingService.getBookings(
+            calendarId, startDate, endDate, statusFilter, resourceIdContains);
         return Response.ok(BookingListResponse.from(bookings)).build();
     }
 

--- a/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
@@ -41,6 +41,7 @@ public class BookingService {
     /**
      * Get bookings by generic booking attributes.
      */
+    @Transactional
     public List<Booking> getBookings(
             UUID calendarId,
             LocalDate startDate,

--- a/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
@@ -39,9 +39,18 @@ public class BookingService {
     SlotService slotService;
 
     /**
-     * Get bookings by calendar, date range and (optionally) lifecycle status
+     * Get bookings by generic booking attributes.
      */
-    public List<Booking> getBookings(UUID calendarId, LocalDate startDate, LocalDate endDate, BookingStatus status) {
+    public List<Booking> getBookings(
+            UUID calendarId,
+            LocalDate startDate,
+            LocalDate endDate,
+            BookingStatus status,
+            String resourceIdContains) {
+        if (resourceIdContains != null && !resourceIdContains.isBlank()) {
+            return Booking.findByResourceIdContaining(
+                calendarId, startDate, endDate, status, resourceIdContains);
+        }
         if (calendarId != null) {
             return status != null
                 ? Booking.findByCalendarDateRangeAndStatus(calendarId, startDate, endDate, status)

--- a/src/main/resources/db/migration/V16__add_booking_resource_search_index.sql
+++ b/src/main/resources/db/migration/V16__add_booking_resource_search_index.sql
@@ -1,0 +1,5 @@
+-- Support case-insensitive substring searches on generic booking resource IDs.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX idx_cld_bookings_resource_lower_trgm
+    ON cld_bookings USING GIN (lower(resource_id) gin_trgm_ops);

--- a/src/test/java/com/microboxlabs/miot/calendar/entity/BookingResourceSearchTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/entity/BookingResourceSearchTest.java
@@ -1,0 +1,50 @@
+package com.microboxlabs.miot.calendar.entity;
+
+import io.quarkus.test.TestTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+class BookingResourceSearchTest {
+
+    @Test
+    @TestTransaction
+    void resourceSearchIsCappedAndPreservesOrdering() {
+        Calendar calendar = new Calendar();
+        calendar.code = "resource-search-" + UUID.randomUUID().toString().substring(0, 8);
+        calendar.name = "Resource search";
+        calendar.persist();
+
+        LocalDate firstDate = LocalDate.of(2020, 1, 1);
+        for (int index = 0; index <= Booking.RESOURCE_SEARCH_MAX_RESULTS; index++) {
+            Slot slot = new Slot();
+            slot.calendar = calendar;
+            slot.slotDate = firstDate.plusDays(index);
+            slot.slotHour = 9;
+            slot.slotMinutes = 0;
+            slot.capacity = 1;
+            slot.persist();
+
+            Booking booking = new Booking();
+            booking.slot = slot;
+            booking.calendar = calendar;
+            booking.resourceId = "RESOURCE-CAP-" + index;
+            booking.persist();
+        }
+
+        List<Booking> results = Booking.findByResourceIdContaining(
+            calendar.id, null, null, null, "resource-cap");
+
+        assertEquals(Booking.RESOURCE_SEARCH_MAX_RESULTS, results.size());
+        assertEquals(firstDate, results.getFirst().slotDate);
+        assertEquals(
+            firstDate.plusDays(Booking.RESOURCE_SEARCH_MAX_RESULTS - 1),
+            results.getLast().slotDate);
+    }
+}

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
@@ -33,10 +33,12 @@ class BookingResourceTest {
     URL bookingsUrl;
 
     private static final String RESOURCE_ID = "SRV-001";
+    private static final String HISTORICAL_RESOURCE_ID = "ARCHIVE_1584908-V";
 
     private String calendarId;
     private String bookingId;
     private LocalDate slotDate;
+    private LocalDate historicalSlotDate;
     private int slotHour = 10;
     private int slotMinutes = 0;
     private boolean setupDone = false;
@@ -52,6 +54,7 @@ class BookingResourceTest {
         if (setupDone) return;
         setupDone = true;
         slotDate = LocalDate.now().plusDays(1);
+        historicalSlotDate = LocalDate.now().minusDays(90);
 
         // Create a calendar with parallelism=2 (2 resources per slot)
         calendarId = given()
@@ -83,7 +86,7 @@ class BookingResourceTest {
                     "daysOfWeek": "1,2,3,4,5,6,7",
                     "validFrom": "%s"
                 }
-                """, LocalDate.now().toString()))
+                """, historicalSlotDate))
             .when()
             .post("/api/v1/miot-calendar/calendars/" + calendarId + "/time-windows")
             .then()
@@ -103,6 +106,44 @@ class BookingResourceTest {
             .post("/api/v1/miot-calendar/slots/generate")
             .then()
             .statusCode(200);
+
+        // Generate and book a slot outside the endpoint's default 30-day
+        // window. Resource searches without dates must still find it.
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "calendarId": "%s",
+                    "startDate": "%s",
+                    "endDate": "%s"
+                }
+                """, calendarId, historicalSlotDate, historicalSlotDate))
+            .when()
+            .post("/api/v1/miot-calendar/slots/generate")
+            .then()
+            .statusCode(200);
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "calendarId": "%s",
+                    "resource": {
+                        "id": "%s",
+                        "type": "GENERIC",
+                        "label": "Historical resource"
+                    },
+                    "slot": {
+                        "date": "%s",
+                        "hour": 9,
+                        "minutes": 0
+                    }
+                }
+                """, calendarId, HISTORICAL_RESOURCE_ID, historicalSlotDate))
+            .when()
+            .post(bookingsUrl.toString())
+            .then()
+            .statusCode(201);
     }
 
     @Test
@@ -156,6 +197,27 @@ class BookingResourceTest {
             .statusCode(200)
             .body("data.size()", greaterThan(0))
             .body("data[0].resource.id", equalTo(RESOURCE_ID));
+    }
+
+    @Test
+    @Order(2)
+    void resourceIdSearchWithoutDatesIncludesHistoricalBookings() {
+        given()
+            .when()
+            .get(bookingsUrl.toString())
+            .then()
+            .statusCode(200)
+            .body("data.resource.id", not(hasItem(HISTORICAL_RESOURCE_ID)));
+
+        given()
+            .queryParam("resourceIdContains", "archive_1584908")
+            .when()
+            .get(bookingsUrl.toString())
+            .then()
+            .statusCode(200)
+            .body("total", equalTo(1))
+            .body("data[0].resource.id", equalTo(HISTORICAL_RESOURCE_ID))
+            .body("data[0].slot.date", equalTo(historicalSlotDate.toString()));
     }
 
     @Test


### PR DESCRIPTION
Closes #45.

## What changed

- Added an optional, resource-neutral `resourceIdContains` filter to `GET /api/v1/miot-calendar/bookings`.
- Matches literal resource-identifier substrings case-insensitively while escaping SQL wildcard characters.
- Date-less resource searches span all booking dates; calendar, date, and lifecycle-status filters still compose normally.
- Preserved the existing today-to-30-days default for list requests without a resource filter.
- Added an integration fixture proving that a booking 90 days old is excluded by the default list but found through the resource filter.

## Why

Consumers need to find historical bookings without teaching miot-calendar client-domain concepts such as service codes. Resource identifiers are calendar-domain data and provide the generic server-side seam.

## Validation

- `./mvnw -q test`
- `./mvnw -q -Dtest=BookingResourceTest test`
- `git diff --check`

## Rollout

Deploy this backend change before the dependent ModularIoT application PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional resource ID substring filtering when listing bookings.
  * Resource searches are case-insensitive and support calendar, date range, and status filters.
  * Results are ordered chronologically.
  * Searches without date limits can find historical bookings, while existing default date behavior remains unchanged.

* **Tests**
  * Added coverage for resource searches involving historical bookings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->