### PR TITLE
feat(bookings): allow explicit overbooking

### DIFF
--- a/src/main/java/com/microboxlabs/miot/calendar/model/BookingRequest.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/BookingRequest.java
@@ -19,11 +19,20 @@ public record BookingRequest(
     SlotData slot,
 
     @Schema(description = "Initial lifecycle status (defaults to PLANNED)", examples = {"PLANNED"})
-    String status
+    String status,
+
+    @Schema(description = "Allow this booking to exceed slot and time-window capacity. "
+        + "Closed and generated overflow slots remain protected.", defaultValue = "false")
+    boolean allowOverbooking
 ) {
     /** Back-compat canonical shape without a status (defaults to PLANNED). */
     public BookingRequest(UUID calendarId, ResourceData resource, SlotData slot) {
-        this(calendarId, resource, slot, null);
+        this(calendarId, resource, slot, null, false);
+    }
+
+    /** Back-compat shape with an initial status and ordinary capacity enforcement. */
+    public BookingRequest(UUID calendarId, ResourceData resource, SlotData slot, String status) {
+        this(calendarId, resource, slot, status, false);
     }
 
     /**

--- a/src/main/java/com/microboxlabs/miot/calendar/model/SlotResponse.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/model/SlotResponse.java
@@ -36,7 +36,9 @@ public record SlotResponse(
     @Schema(required = true, description = "Number of current bookings in this slot", minimum = "0")
     Integer currentOccupancy,
 
-    @Schema(required = true, description = "Remaining available capacity", minimum = "0")
+    @Schema(required = true, description = "Remaining available capacity; never negative "
+        + "(an explicitly overbooked slot reports 0 here and the real count in currentOccupancy)",
+        minimum = "0")
     Integer availableCapacity,
 
     @Schema(required = true, description = "Current status of the slot")
@@ -61,7 +63,7 @@ public record SlotResponse(
             slot.slotMinutes,
             slot.capacity,
             slot.currentOccupancy,
-            slot.capacity - slot.currentOccupancy,
+            Math.max(0, slot.capacity - slot.currentOccupancy),
             slot.status,
             slot.createdAt,
             slot.updatedAt

--- a/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/service/BookingService.java
@@ -99,7 +99,7 @@ public class BookingService {
         ));
 
         // Validate the booking
-        validationService.validateBooking(slot, request.resource().id());
+        validationService.validateBooking(slot, request.resource().id(), request.allowOverbooking());
 
         // Get calendar
         Calendar calendar = Calendar.findById(request.calendarId());

--- a/src/main/java/com/microboxlabs/miot/calendar/validation/BookingValidationService.java
+++ b/src/main/java/com/microboxlabs/miot/calendar/validation/BookingValidationService.java
@@ -25,14 +25,25 @@ public class BookingValidationService {
      * @throws BookingValidationException if validation fails
      */
     public void validateBooking(Slot slot, String resourceId) {
+        validateBooking(slot, resourceId, false);
+    }
+
+    /**
+     * Validate a booking create request, optionally bypassing capacity limits.
+     * Structural booking guards (closed/generated-overflow slots and duplicate
+     * resources) always apply.
+     */
+    public void validateBooking(Slot slot, String resourceId, boolean allowOverbooking) {
         // 1. Check slot status
-        validateSlotStatus(slot);
+        validateSlotStatus(slot, allowOverbooking);
 
-        // 2. Check the parent window's total-capacity cap (MANUAL windows)
-        validateWindowCapacity(slot);
+        if (!allowOverbooking) {
+            // 2. Check the parent window's total-capacity cap (MANUAL windows)
+            validateWindowCapacity(slot);
 
-        // 3. Check slot capacity
-        validateSlotCapacity(slot);
+            // 3. Check slot capacity
+            validateSlotCapacity(slot);
+        }
 
         // 4. Check resource not already in slot
         validateResourceNotInSlot(slot, resourceId);
@@ -94,6 +105,10 @@ public class BookingValidationService {
      * Validate slot is open for bookings
      */
     private void validateSlotStatus(Slot slot) {
+        validateSlotStatus(slot, false);
+    }
+
+    private void validateSlotStatus(Slot slot, boolean allowOverbooking) {
         if (slot.status == SlotStatus.CLOSED) {
             throw new BookingValidationException(
                 "Slot is closed for bookings",
@@ -106,7 +121,7 @@ public class BookingValidationService {
                 "SLOT_OVERFLOW"
             );
         }
-        if (slot.status == SlotStatus.FULL) {
+        if (slot.status == SlotStatus.FULL && !allowOverbooking) {
             throw new BookingValidationException(
                 "Slot is at full capacity",
                 "SLOT_FULL"

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
@@ -43,14 +43,16 @@ class BookingResourceTest {
     private int slotMinutes = 0;
     private boolean setupDone = false;
 
-    @BeforeEach
-    void setupRestAssured() {
-        RestAssured.baseURI = url.toString();
-        RestAssured.port = url.getPort();
-    }
-
+    /**
+     * One @BeforeEach only: the shared-fixture block below calls {@code given()}, which reads the
+     * base URI configured here. JUnit does not order two @BeforeEach methods of the same class, so
+     * they cannot be split.
+     */
     @BeforeEach
     void setup() {
+        RestAssured.baseURI = url.toString();
+        RestAssured.port = url.getPort();
+
         if (setupDone) return;
         setupDone = true;
         slotDate = LocalDate.now().plusDays(1);
@@ -361,6 +363,8 @@ class BookingResourceTest {
             .statusCode(200)
             .body("data.find { it.slotHour == 10 && it.slotMinutes == 0 }.currentOccupancy", equalTo(3))
             .body("data.find { it.slotHour == 10 && it.slotMinutes == 0 }.capacity", equalTo(2))
+            // Occupancy stays observable past capacity; availableCapacity never goes negative.
+            .body("data.find { it.slotHour == 10 && it.slotMinutes == 0 }.availableCapacity", equalTo(0))
             .body("data.find { it.slotHour == 10 && it.slotMinutes == 0 }.status", equalTo("FULL"));
     }
 

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/BookingResourceTest.java
@@ -325,6 +325,65 @@ class BookingResourceTest {
     }
 
     @Test
+    @Order(8)
+    void testSlotFullCanBeExplicitlyOverbooked() {
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "calendarId": "%s",
+                    "resource": {
+                        "id": "SRV-003",
+                        "type": "SERVICE",
+                        "label": "Overbooked service"
+                    },
+                    "slot": {
+                        "date": "%s",
+                        "hour": %d,
+                        "minutes": %d
+                    },
+                    "allowOverbooking": true
+                }
+                """, calendarId, slotDate, slotHour, slotMinutes))
+            .when()
+            .post(bookingsUrl.toString())
+            .then()
+            .statusCode(201)
+            .body("resource.id", equalTo("SRV-003"));
+
+        given()
+            .queryParam("calendarId", calendarId)
+            .queryParam("startDate", slotDate.toString())
+            .queryParam("endDate", slotDate.toString())
+            .when()
+            .get("/api/v1/miot-calendar/slots")
+            .then()
+            .statusCode(200)
+            .body("data.find { it.slotHour == 10 && it.slotMinutes == 0 }.currentOccupancy", equalTo(3))
+            .body("data.find { it.slotHour == 10 && it.slotMinutes == 0 }.capacity", equalTo(2))
+            .body("data.find { it.slotHour == 10 && it.slotMinutes == 0 }.status", equalTo("FULL"));
+    }
+
+    @Test
+    @Order(9)
+    void testOverbookingStillRejectsDuplicateResource() {
+        given()
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                    "calendarId": "%s",
+                    "resource": { "id": "SRV-003", "type": "SERVICE" },
+                    "slot": { "date": "%s", "hour": %d, "minutes": %d },
+                    "allowOverbooking": true
+                }
+                """, calendarId, slotDate, slotHour, slotMinutes))
+            .when()
+            .post(bookingsUrl.toString())
+            .then()
+            .statusCode(409);
+    }
+
+    @Test
     @Order(7)
     void testUpdateBookingResourceData() {
         // Update the booking's resource payload in place (slot unchanged).
@@ -395,7 +454,7 @@ class BookingResourceTest {
     }
 
     @Test
-    @Order(8)
+    @Order(10)
     void testCancelBooking() {
         given()
             .when()
@@ -443,7 +502,7 @@ class BookingResourceTest {
      * BookingValidationService already refuses).
      */
     @Test
-    @Order(9)
+    @Order(11)
     void testBookingRejectedOnBlockSlot() {
         // Fresh calendar so the BLOCK doesn't disturb sibling tests.
         String blockedCalendarId = given()

--- a/src/test/java/com/microboxlabs/miot/calendar/resource/ManualSlotDurationResourceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/resource/ManualSlotDurationResourceTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.URL;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
@@ -169,5 +171,47 @@ class ManualSlotDurationResourceTest {
             .body("[0].slotDurationMinutes", equalTo(30))  // unchanged
             .body("[0].totalSlots", equalTo(8))            // unchanged
             .body("[0].bookableSlots", equalTo(8));        // unchanged (== totalSlots)
+    }
+
+    @Test
+    void explicitOverbookingBypassesManualWindowCapacity() {
+        String calendarId = createCalendar("msd-overbook", 1);
+        LocalDate bookingDate = VALID_FROM.with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY));
+        given().contentType(ContentType.JSON).body(timeWindowBody("MANUAL", 60, 8, 10, 1))
+            .when().post(CALENDARS_PATH + "/" + calendarId + "/time-windows")
+            .then().statusCode(201);
+
+        given().contentType(ContentType.JSON).body(String.format("""
+            { "calendarId": "%s", "startDate": "%s", "endDate": "%s" }
+            """, calendarId, bookingDate, bookingDate))
+            .when().post("/api/v1/miot-calendar/slots/generate")
+            .then().statusCode(200);
+
+        given().contentType(ContentType.JSON)
+            .body(bookingBody(calendarId, "manual-first", bookingDate, 8, false))
+            .when().post("/api/v1/miot-calendar/bookings")
+            .then().statusCode(201);
+
+        given().contentType(ContentType.JSON)
+            .body(bookingBody(calendarId, "manual-second", bookingDate, 9, false))
+            .when().post("/api/v1/miot-calendar/bookings")
+            .then().statusCode(409);
+
+        given().contentType(ContentType.JSON)
+            .body(bookingBody(calendarId, "manual-second", bookingDate, 9, true))
+            .when().post("/api/v1/miot-calendar/bookings")
+            .then().statusCode(201);
+    }
+
+    private static String bookingBody(String calendarId, String resourceId, LocalDate date,
+                                      int hour, boolean allowOverbooking) {
+        return String.format("""
+            {
+                "calendarId": "%s",
+                "resource": { "id": "%s", "type": "SERVICE" },
+                "slot": { "date": "%s", "hour": %d, "minutes": 0 },
+                "allowOverbooking": %b
+            }
+            """, calendarId, resourceId, date, hour, allowOverbooking);
     }
 }

--- a/src/test/java/com/microboxlabs/miot/calendar/validation/BookingValidationServiceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/validation/BookingValidationServiceTest.java
@@ -39,6 +39,20 @@ class BookingValidationServiceTest {
     }
 
     @Test
+    void overbookingStillRejectsOverflowSlot() {
+        BookingValidationException ex = assertThrows(BookingValidationException.class,
+                () -> validator.validateBooking(slotWithStatus(SlotStatus.OVERFLOW), "truck-1", true));
+        assertEquals("SLOT_OVERFLOW", ex.getErrorCode());
+    }
+
+    @Test
+    void overbookingStillRejectsClosedSlot() {
+        BookingValidationException ex = assertThrows(BookingValidationException.class,
+                () -> validator.validateBooking(slotWithStatus(SlotStatus.CLOSED), "truck-1", true));
+        assertEquals("SLOT_CLOSED", ex.getErrorCode());
+    }
+
+    @Test
     void rejectsFullSlot() {
         BookingValidationException ex = assertThrows(BookingValidationException.class,
                 () -> validator.validateBooking(slotWithStatus(SlotStatus.FULL), "truck-1"));

--- a/src/test/java/com/microboxlabs/miot/calendar/validation/BookingValidationServiceTest.java
+++ b/src/test/java/com/microboxlabs/miot/calendar/validation/BookingValidationServiceTest.java
@@ -26,36 +26,41 @@ class BookingValidationServiceTest {
 
     @Test
     void rejectsOverflowSlot() {
+        Slot slot = slotWithStatus(SlotStatus.OVERFLOW);
         BookingValidationException ex = assertThrows(BookingValidationException.class,
-                () -> validator.validateBooking(slotWithStatus(SlotStatus.OVERFLOW), "truck-1"));
+                () -> validator.validateBooking(slot, "truck-1"));
         assertEquals("SLOT_OVERFLOW", ex.getErrorCode());
     }
 
     @Test
     void rejectsClosedSlot() {
+        Slot slot = slotWithStatus(SlotStatus.CLOSED);
         BookingValidationException ex = assertThrows(BookingValidationException.class,
-                () -> validator.validateBooking(slotWithStatus(SlotStatus.CLOSED), "truck-1"));
+                () -> validator.validateBooking(slot, "truck-1"));
         assertEquals("SLOT_CLOSED", ex.getErrorCode());
     }
 
     @Test
     void overbookingStillRejectsOverflowSlot() {
+        Slot slot = slotWithStatus(SlotStatus.OVERFLOW);
         BookingValidationException ex = assertThrows(BookingValidationException.class,
-                () -> validator.validateBooking(slotWithStatus(SlotStatus.OVERFLOW), "truck-1", true));
+                () -> validator.validateBooking(slot, "truck-1", true));
         assertEquals("SLOT_OVERFLOW", ex.getErrorCode());
     }
 
     @Test
     void overbookingStillRejectsClosedSlot() {
+        Slot slot = slotWithStatus(SlotStatus.CLOSED);
         BookingValidationException ex = assertThrows(BookingValidationException.class,
-                () -> validator.validateBooking(slotWithStatus(SlotStatus.CLOSED), "truck-1", true));
+                () -> validator.validateBooking(slot, "truck-1", true));
         assertEquals("SLOT_CLOSED", ex.getErrorCode());
     }
 
     @Test
     void rejectsFullSlot() {
+        Slot slot = slotWithStatus(SlotStatus.FULL);
         BookingValidationException ex = assertThrows(BookingValidationException.class,
-                () -> validator.validateBooking(slotWithStatus(SlotStatus.FULL), "truck-1"));
+                () -> validator.validateBooking(slot, "truck-1"));
         assertEquals("SLOT_FULL", ex.getErrorCode());
     }
 }


### PR DESCRIPTION
## Summary

- add optional `allowOverbooking` to booking creation
- bypass slot and MANUAL-window capacity only when explicitly requested
- preserve CLOSED, generated OVERFLOW, and duplicate-resource validation
- keep occupancy accounting observable beyond configured capacity

## Tests

- `./mvnw -DskipITs test` (160 tests passing against isolated PostgreSQL)

## Coordination

Required by microboxlabs/modulariot#1167. Deploy this API support before or together with the coordinator PR.

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional overbooking setting for bookings.
  * When enabled, full slots and capacity limits can accept additional bookings.
  * Closed slots, overflow slots, and duplicate-resource restrictions remain enforced.
  * Existing booking behavior remains unchanged unless overbooking is explicitly enabled.

* **Tests**
  * Added coverage for overbooking in standard and manual scheduling windows.
  * Verified that protected slot conditions continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->